### PR TITLE
New file system mkt level struct added, for high speed

### DIFF
--- a/metrics/cpu.go
+++ b/metrics/cpu.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The CortexTheseus Authors
+// This file is part of the CortexTheseus library.
+//
+// The CortexTheseus library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The CortexTheseus library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the CortexTheseus library. If not, see <http://www.gnu.org/licenses/>.
+
+package metrics
+
+import "github.com/elastic/gosigar"
+
+// CPUStats is the system and process CPU stats.
+type CPUStats struct {
+	GlobalTime int64 // Time spent by the CPU working on all processes
+	GlobalWait int64 // Time spent by waiting on disk for all processes
+	LocalTime  int64 // Time spent by the CPU working on this process
+}
+
+// ReadCPUStats retrieves the current CPU stats.
+func ReadCPUStats(stats *CPUStats) {
+	global := gosigar.Cpu{}
+	global.Get()
+
+	stats.GlobalTime = int64(global.User + global.Nice + global.Sys)
+	stats.GlobalWait = int64(global.Wait)
+	stats.LocalTime = getProcessCPUTime()
+}

--- a/metrics/cpu_syscall.go
+++ b/metrics/cpu_syscall.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The CortexTheseus Authors
+// This file is part of the CortexTheseus library.
+//
+// The CortexTheseus library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The CortexTheseus library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the CortexTheseus library. If not, see <http://www.gnu.org/licenses/>.
+
+// +build !windows
+
+package metrics
+
+import (
+	"syscall"
+
+	"github.com/CortexFoundation/CortexTheseus/log"
+)
+
+// getProcessCPUTime retrieves the process' CPU time since program startup.
+func getProcessCPUTime() int64 {
+	var usage syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil {
+		log.Warn("Failed to retrieve CPU time", "err", err)
+		return 0
+	}
+	return int64(usage.Utime.Sec+usage.Stime.Sec)*100 + int64(usage.Utime.Usec+usage.Stime.Usec)/10000 //nolint:unconvert
+}

--- a/metrics/cpu_windows.go
+++ b/metrics/cpu_windows.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The CortexTheseus Authors
+// This file is part of the CortexTheseus library.
+//
+// The CortexTheseus library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The CortexTheseus library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the CortexTheseus library. If not, see <http://www.gnu.org/licenses/>.
+
+package metrics
+
+// getProcessCPUTime returns 0 on Windows as there is no system call to resolve
+// the actual process' CPU time.
+func getProcessCPUTime() int64 {
+	return 0
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -15,24 +15,41 @@ import (
 )
 
 // Enabled is checked by the constructor functions for all of the
-// standard metrics.  If it is true, the metric returned is a stub.
+// standard metrics. If it is true, the metric returned is a stub.
 //
 // This global kill-switch helps quantify the observer effect and makes
 // for less cluttered pprof profiles.
-var Enabled bool = false
+var Enabled = false
 
-// MetricsEnabledFlag is the CLI flag name to use to enable metrics collections.
-const MetricsEnabledFlag = "metrics"
-const DashboardEnabledFlag = "dashboard"
+// EnabledExpensive is a soft-flag meant for external packages to check if costly
+// metrics gathering is allowed or not. The goal is to separate standard metrics
+// for health monitoring and debug metrics that might impact runtime performance.
+var EnabledExpensive = false
+
+// enablerFlags is the CLI flag names to use to enable metrics collections.
+var enablerFlags = []string{"metrics"}
+
+// expensiveEnablerFlags is the CLI flag names to use to enable metrics collections.
+var expensiveEnablerFlags = []string{"metrics.expensive"}
 
 // Init enables or disables the metrics system. Since we need this to run before
 // any other code gets to create meters and timers, we'll actually do an ugly hack
 // and peek into the command line args for the metrics flag.
 func init() {
 	for _, arg := range os.Args {
-		if flag := strings.TrimLeft(arg, "-"); flag == MetricsEnabledFlag || flag == DashboardEnabledFlag {
-			log.Info("Enabling metrics collection")
-			Enabled = true
+		flag := strings.TrimLeft(arg, "-")
+
+		for _, enabler := range enablerFlags {
+			if !Enabled && flag == enabler {
+				log.Info("Enabling metrics collection")
+				Enabled = true
+			}
+		}
+		for _, enabler := range expensiveEnablerFlags {
+			if !EnabledExpensive && flag == enabler {
+				log.Info("Enabling expensive metrics collection")
+				EnabledExpensive = true
+			}
 		}
 	}
 }
@@ -44,41 +61,56 @@ func CollectProcessMetrics(refresh time.Duration) {
 	if !Enabled {
 		return
 	}
+	refreshFreq := int64(refresh / time.Second)
+
 	// Create the various data collectors
+	cpuStats := make([]*CPUStats, 2)
 	memstats := make([]*runtime.MemStats, 2)
 	diskstats := make([]*DiskStats, 2)
 	for i := 0; i < len(memstats); i++ {
+		cpuStats[i] = new(CPUStats)
 		memstats[i] = new(runtime.MemStats)
 		diskstats[i] = new(DiskStats)
 	}
 	// Define the various metrics to collect
-	memAllocs := GetOrRegisterMeter("system/memory/allocs", DefaultRegistry)
-	memFrees := GetOrRegisterMeter("system/memory/frees", DefaultRegistry)
-	memInuse := GetOrRegisterMeter("system/memory/inuse", DefaultRegistry)
-	memPauses := GetOrRegisterMeter("system/memory/pauses", DefaultRegistry)
+	var (
+		cpuSysLoad    = GetOrRegisterGauge("system/cpu/sysload", DefaultRegistry)
+		cpuSysWait    = GetOrRegisterGauge("system/cpu/syswait", DefaultRegistry)
+		cpuProcLoad   = GetOrRegisterGauge("system/cpu/procload", DefaultRegistry)
+		cpuThreads    = GetOrRegisterGauge("system/cpu/threads", DefaultRegistry)
+		cpuGoroutines = GetOrRegisterGauge("system/cpu/goroutines", DefaultRegistry)
 
-	var diskReads, diskReadBytes, diskWrites, diskWriteBytes Meter
-	var diskReadBytesCounter, diskWriteBytesCounter Counter
-	if err := ReadDiskStats(diskstats[0]); err == nil {
-		diskReads = GetOrRegisterMeter("system/disk/readcount", DefaultRegistry)
-		diskReadBytes = GetOrRegisterMeter("system/disk/readdata", DefaultRegistry)
-		diskReadBytesCounter = GetOrRegisterCounter("system/disk/readbytes", DefaultRegistry)
-		diskWrites = GetOrRegisterMeter("system/disk/writecount", DefaultRegistry)
-		diskWriteBytes = GetOrRegisterMeter("system/disk/writedata", DefaultRegistry)
+		memPauses = GetOrRegisterMeter("system/memory/pauses", DefaultRegistry)
+		memAllocs = GetOrRegisterMeter("system/memory/allocs", DefaultRegistry)
+		memFrees  = GetOrRegisterMeter("system/memory/frees", DefaultRegistry)
+		memHeld   = GetOrRegisterGauge("system/memory/held", DefaultRegistry)
+		memUsed   = GetOrRegisterGauge("system/memory/used", DefaultRegistry)
+
+		diskReads             = GetOrRegisterMeter("system/disk/readcount", DefaultRegistry)
+		diskReadBytes         = GetOrRegisterMeter("system/disk/readdata", DefaultRegistry)
+		diskReadBytesCounter  = GetOrRegisterCounter("system/disk/readbytes", DefaultRegistry)
+		diskWrites            = GetOrRegisterMeter("system/disk/writecount", DefaultRegistry)
+		diskWriteBytes        = GetOrRegisterMeter("system/disk/writedata", DefaultRegistry)
 		diskWriteBytesCounter = GetOrRegisterCounter("system/disk/writebytes", DefaultRegistry)
-	} else {
-		log.Debug("Failed to read disk metrics", "err", err)
-	}
+	)
 	// Iterate loading the different stats and updating the meters
 	for i := 1; ; i++ {
 		location1 := i % 2
 		location2 := (i - 1) % 2
 
+		ReadCPUStats(cpuStats[location1])
+		cpuSysLoad.Update((cpuStats[location1].GlobalTime - cpuStats[location2].GlobalTime) / refreshFreq)
+		cpuSysWait.Update((cpuStats[location1].GlobalWait - cpuStats[location2].GlobalWait) / refreshFreq)
+		cpuProcLoad.Update((cpuStats[location1].LocalTime - cpuStats[location2].LocalTime) / refreshFreq)
+		cpuThreads.Update(int64(threadCreateProfile.Count()))
+		cpuGoroutines.Update(int64(runtime.NumGoroutine()))
+
 		runtime.ReadMemStats(memstats[location1])
+		memPauses.Mark(int64(memstats[location1].PauseTotalNs - memstats[location2].PauseTotalNs))
 		memAllocs.Mark(int64(memstats[location1].Mallocs - memstats[location2].Mallocs))
 		memFrees.Mark(int64(memstats[location1].Frees - memstats[location2].Frees))
-		memInuse.Mark(int64(memstats[location1].Alloc - memstats[location2].Alloc))
-		memPauses.Mark(int64(memstats[location1].PauseTotalNs - memstats[location2].PauseTotalNs))
+		memHeld.Update(int64(memstats[location1].HeapSys - memstats[location1].HeapReleased))
+		memUsed.Update(int64(memstats[location1].Alloc))
 
 		if ReadDiskStats(diskstats[location1]) == nil {
 			diskReads.Mark(diskstats[location1].ReadCount - diskstats[location2].ReadCount)

--- a/params/fs.go
+++ b/params/fs.go
@@ -6,5 +6,6 @@ const (
 	SyncBatch = 4096
 	Delay     = 12
 	//Scope     = 4
-	TIER = 3
+	TIER  = 3
+	LEAFS = 1024
 )

--- a/params/fs.go
+++ b/params/fs.go
@@ -7,5 +7,5 @@ const (
 	Delay     = 12
 	//Scope     = 4
 	TIER  = 3
-	LEAFS = 1024
+	LEAFS = 32768
 )

--- a/torrentfs/storage.go
+++ b/torrentfs/storage.go
@@ -199,7 +199,7 @@ func (fs *FileStorage) addLeaf(block *types.Block, init bool) error {
 	number := block.Number
 	leaf := BlockContent{x: block.Hash.String()}
 
-	if len(fs.leaves) >= 512 {
+	if len(fs.leaves) >= params.LEAFS {
 		fs.leaves = nil
 		fs.leaves = append(fs.leaves, BlockContent{x: hexutil.Encode(fs.tree.MerkleRoot())})
 		log.Info("Next tree level", "leaf", len(fs.leaves), "root", hexutil.Encode(fs.tree.MerkleRoot()))

--- a/torrentfs/storage.go
+++ b/torrentfs/storage.go
@@ -196,7 +196,6 @@ func (fs *FileStorage) initMerkleTree() error {
 }
 
 func (fs *FileStorage) addLeaf(block *types.Block, init bool) error {
-	defer func(start time.Time) { fs.treeUpdates += time.Since(start) }(time.Now())
 	number := block.Number
 	leaf := BlockContent{x: block.Hash.String()}
 
@@ -207,6 +206,9 @@ func (fs *FileStorage) addLeaf(block *types.Block, init bool) error {
 	}
 
 	fs.leaves = append(fs.leaves, leaf)
+
+	defer func(start time.Time) { fs.treeUpdates += time.Since(start) }(time.Now())
+
 	if err := fs.tree.RebuildTreeWith(fs.leaves); err == nil {
 		if err := fs.writeRoot(number, fs.tree.MerkleRoot()); err != nil {
 			return err

--- a/torrentfs/storage.go
+++ b/torrentfs/storage.go
@@ -202,7 +202,7 @@ func (fs *FileStorage) addLeaf(block *types.Block, init bool) error {
 	if len(fs.leaves) >= params.LEAFS {
 		fs.leaves = nil
 		fs.leaves = append(fs.leaves, BlockContent{x: hexutil.Encode(fs.tree.MerkleRoot())})
-		log.Info("Next tree level", "leaf", len(fs.leaves), "root", hexutil.Encode(fs.tree.MerkleRoot()))
+		log.Debug("Next tree level", "leaf", len(fs.leaves), "root", hexutil.Encode(fs.tree.MerkleRoot()))
 	}
 
 	fs.leaves = append(fs.leaves, leaf)
@@ -214,7 +214,7 @@ func (fs *FileStorage) addLeaf(block *types.Block, init bool) error {
 			return err
 		}
 
-		log.Info("New leaf", "number", number, "root", hexutil.Encode(fs.tree.MerkleRoot()), "leaves", len(fs.leaves), "blocks", len(fs.blocks), "time", fs.treeUpdates, "init", init)
+		log.Debug("New leaf", "number", number, "root", hexutil.Encode(fs.tree.MerkleRoot()), "leaves", len(fs.leaves), "blocks", len(fs.blocks), "time", fs.treeUpdates, "init", init)
 
 		return nil
 	} else {

--- a/torrentfs/storage.go
+++ b/torrentfs/storage.go
@@ -4,28 +4,20 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"github.com/CortexFoundation/CortexTheseus/common/hexutil"
 	"github.com/CortexFoundation/CortexTheseus/params"
 	"github.com/CortexFoundation/CortexTheseus/torrentfs/types"
-	//"fmt"
 	"github.com/pborman/uuid"
 	"os"
 	"path/filepath"
-	//"path"
 	"sort"
-	//"io/ioutil"
 	"strconv"
-	//"strings"
-	"github.com/CortexFoundation/CortexTheseus/common/hexutil"
-	//"sync"
-	//"sync/atomic"
 	"time"
 
 	"crypto/sha256"
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/log"
-	//"github.com/anacrolix/torrent/metainfo"
 	bolt "github.com/etcd-io/bbolt"
-	//"math/rand"
 )
 
 //const (
@@ -71,7 +63,8 @@ type FileStorage struct {
 	dataDir string
 	//tmpCache  *lru.Cache
 	//indexLock sync.RWMutex
-	config *Config
+	config      *Config
+	treeUpdates time.Duration
 }
 
 //var initConfig *Config = nil
@@ -192,7 +185,7 @@ func (fs *FileStorage) initMerkleTree() error {
 	}
 	fs.tree = tr
 	for _, block := range fs.blocks {
-		if err := fs.addLeaf(block); err != nil {
+		if err := fs.addLeaf(block, true); err != nil {
 			panic("Storage merkletree construct failed")
 		}
 	}
@@ -202,15 +195,15 @@ func (fs *FileStorage) initMerkleTree() error {
 	return nil
 }
 
-func (fs *FileStorage) addLeaf(block *types.Block) error {
+func (fs *FileStorage) addLeaf(block *types.Block, init bool) error {
+	defer func(start time.Time) { fs.treeUpdates += time.Since(start) }(time.Now())
 	number := block.Number
 	leaf := BlockContent{x: block.Hash.String()}
 
 	if len(fs.leaves) >= 512 {
 		fs.leaves = nil
-
 		fs.leaves = append(fs.leaves, BlockContent{x: hexutil.Encode(fs.tree.MerkleRoot())})
-		log.Info("New tree level", "leaf", len(fs.leaves), "root", hexutil.Encode(fs.tree.MerkleRoot()))
+		log.Info("Next tree level", "leaf", len(fs.leaves), "root", hexutil.Encode(fs.tree.MerkleRoot()))
 	}
 
 	fs.leaves = append(fs.leaves, leaf)
@@ -219,7 +212,7 @@ func (fs *FileStorage) addLeaf(block *types.Block) error {
 			return err
 		}
 
-		log.Debug("New leaf", "number", number, "root", hexutil.Encode(fs.tree.MerkleRoot()), "leaves", len(fs.leaves), "blocks", len(fs.blocks)) //, "version", common.ToHex(version)) //MerkleRoot())
+		log.Info("New leaf", "number", number, "root", hexutil.Encode(fs.tree.MerkleRoot()), "leaves", len(fs.leaves), "blocks", len(fs.blocks), "time", fs.treeUpdates, "init", init)
 
 		return nil
 	} else {
@@ -538,7 +531,7 @@ func (fs *FileStorage) AddBlock(b *types.Block) error {
 
 			return buk.Put(k, v)
 		}); err == nil {
-			if err := fs.addLeaf(b); err == nil {
+			if err := fs.addLeaf(b, false); err == nil {
 				if err := fs.writeCheckPoint(); err == nil {
 					fs.CheckPoint = b.Number
 				} else {

--- a/torrentfs/storage.go
+++ b/torrentfs/storage.go
@@ -205,13 +205,21 @@ func (fs *FileStorage) initMerkleTree() error {
 func (fs *FileStorage) addLeaf(block *types.Block) error {
 	number := block.Number
 	leaf := BlockContent{x: block.Hash.String()}
+
+	if len(fs.leaves) >= 512 {
+		fs.leaves = nil
+
+		fs.leaves = append(fs.leaves, BlockContent{x: hexutil.Encode(fs.tree.MerkleRoot())})
+		log.Info("New tree level", "leaf", len(fs.leaves), "root", hexutil.Encode(fs.tree.MerkleRoot()))
+	}
+
 	fs.leaves = append(fs.leaves, leaf)
 	if err := fs.tree.RebuildTreeWith(fs.leaves); err == nil {
 		if err := fs.writeRoot(number, fs.tree.MerkleRoot()); err != nil {
 			return err
 		}
 
-		log.Debug("New leaf", "number", number, "root", hexutil.Encode(fs.tree.MerkleRoot())) //, "version", common.ToHex(version)) //MerkleRoot())
+		log.Debug("New leaf", "number", number, "root", hexutil.Encode(fs.tree.MerkleRoot()), "leaves", len(fs.leaves), "blocks", len(fs.blocks)) //, "version", common.ToHex(version)) //MerkleRoot())
 
 		return nil
 	} else {

--- a/torrentfs/types/merkle_tree_test.go
+++ b/torrentfs/types/merkle_tree_test.go
@@ -1,6 +1,3 @@
-// Copyright 2017 Cameron Bergoon
-// Licensed under the MIT License, see LICENCE file for details.
-
 package types
 
 import (

--- a/torrentfs/types/merkle_tree_test.go
+++ b/torrentfs/types/merkle_tree_test.go
@@ -1,0 +1,551 @@
+// Copyright 2017 Cameron Bergoon
+// Licensed under the MIT License, see LICENCE file for details.
+
+package types
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/sha256"
+	"github.com/CortexFoundation/CortexTheseus/torrentfs/types"
+	"hash"
+	"testing"
+)
+
+//TestSHA256Content implements the Content interface provided by merkletree and represents the content stored in the tree.
+type TestSHA256Content struct {
+	x string
+}
+
+//CalculateHash hashes the values of a TestSHA256Content
+func (t TestSHA256Content) CalculateHash() ([]byte, error) {
+	h := sha256.New()
+	if _, err := h.Write([]byte(t.x)); err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
+}
+
+//Equals tests for equality of two Contents
+func (t TestSHA256Content) Equals(other types.Content) (bool, error) {
+	return t.x == other.(TestSHA256Content).x, nil
+}
+
+//TestContent implements the Content interface provided by merkletree and represents the content stored in the tree.
+type TestMD5Content struct {
+	x string
+}
+
+//CalculateHash hashes the values of a TestContent
+func (t TestMD5Content) CalculateHash() ([]byte, error) {
+	h := md5.New()
+	if _, err := h.Write([]byte(t.x)); err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
+}
+
+//Equals tests for equality of two Contents
+func (t TestMD5Content) Equals(other types.Content) (bool, error) {
+	return t.x == other.(TestMD5Content).x, nil
+}
+
+func calHash(hash []byte, hashStrategy func() hash.Hash) ([]byte, error) {
+	h := hashStrategy()
+	if _, err := h.Write(hash); err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
+}
+
+var table = []struct {
+	testCaseId          int
+	hashStrategy        func() hash.Hash
+	hashStrategyName    string
+	defaultHashStrategy bool
+	contents            []types.Content
+	expectedHash        []byte
+	notInContents       types.Content
+}{
+	{
+		testCaseId:          0,
+		hashStrategy:        sha256.New,
+		hashStrategyName:    "sha256",
+		defaultHashStrategy: true,
+		contents: []types.Content{
+			TestSHA256Content{
+				x: "Hello",
+			},
+			TestSHA256Content{
+				x: "Hi",
+			},
+			TestSHA256Content{
+				x: "Hey",
+			},
+			TestSHA256Content{
+				x: "Hola",
+			},
+		},
+		notInContents: TestSHA256Content{x: "NotInTestTable"},
+		expectedHash:  []byte{95, 48, 204, 128, 19, 59, 147, 148, 21, 110, 36, 178, 51, 240, 196, 190, 50, 178, 78, 68, 187, 51, 129, 240, 44, 123, 165, 38, 25, 208, 254, 188},
+	},
+	{
+		testCaseId:          1,
+		hashStrategy:        sha256.New,
+		hashStrategyName:    "sha256",
+		defaultHashStrategy: true,
+		contents: []types.Content{
+			TestSHA256Content{
+				x: "Hello",
+			},
+			TestSHA256Content{
+				x: "Hi",
+			},
+			TestSHA256Content{
+				x: "Hey",
+			},
+		},
+		notInContents: TestSHA256Content{x: "NotInTestTable"},
+		expectedHash:  []byte{189, 214, 55, 197, 35, 237, 92, 14, 171, 121, 43, 152, 109, 177, 136, 80, 194, 57, 162, 226, 56, 2, 179, 106, 255, 38, 187, 104, 251, 63, 224, 8},
+	},
+	{
+		testCaseId:          2,
+		hashStrategy:        sha256.New,
+		hashStrategyName:    "sha256",
+		defaultHashStrategy: true,
+		contents: []types.Content{
+			TestSHA256Content{
+				x: "Hello",
+			},
+			TestSHA256Content{
+				x: "Hi",
+			},
+			TestSHA256Content{
+				x: "Hey",
+			},
+			TestSHA256Content{
+				x: "Greetings",
+			},
+			TestSHA256Content{
+				x: "Hola",
+			},
+		},
+		notInContents: TestSHA256Content{x: "NotInTestTable"},
+		expectedHash:  []byte{46, 216, 115, 174, 13, 210, 55, 39, 119, 197, 122, 104, 93, 144, 112, 131, 202, 151, 41, 14, 80, 143, 21, 71, 140, 169, 139, 173, 50, 37, 235, 188},
+	},
+	{
+		testCaseId:          3,
+		hashStrategy:        sha256.New,
+		hashStrategyName:    "sha256",
+		defaultHashStrategy: true,
+		contents: []types.Content{
+			TestSHA256Content{
+				x: "123",
+			},
+			TestSHA256Content{
+				x: "234",
+			},
+			TestSHA256Content{
+				x: "345",
+			},
+			TestSHA256Content{
+				x: "456",
+			},
+			TestSHA256Content{
+				x: "1123",
+			},
+			TestSHA256Content{
+				x: "2234",
+			},
+			TestSHA256Content{
+				x: "3345",
+			},
+			TestSHA256Content{
+				x: "4456",
+			},
+		},
+		notInContents: TestSHA256Content{x: "NotInTestTable"},
+		expectedHash:  []byte{30, 76, 61, 40, 106, 173, 169, 183, 149, 2, 157, 246, 162, 218, 4, 70, 153, 148, 62, 162, 90, 24, 173, 250, 41, 149, 173, 121, 141, 187, 146, 43},
+	},
+	{
+		testCaseId:          4,
+		hashStrategy:        sha256.New,
+		hashStrategyName:    "sha256",
+		defaultHashStrategy: true,
+		contents: []types.Content{
+			TestSHA256Content{
+				x: "123",
+			},
+			TestSHA256Content{
+				x: "234",
+			},
+			TestSHA256Content{
+				x: "345",
+			},
+			TestSHA256Content{
+				x: "456",
+			},
+			TestSHA256Content{
+				x: "1123",
+			},
+			TestSHA256Content{
+				x: "2234",
+			},
+			TestSHA256Content{
+				x: "3345",
+			},
+			TestSHA256Content{
+				x: "4456",
+			},
+			TestSHA256Content{
+				x: "5567",
+			},
+		},
+		notInContents: TestSHA256Content{x: "NotInTestTable"},
+		expectedHash:  []byte{143, 37, 161, 192, 69, 241, 248, 56, 169, 87, 79, 145, 37, 155, 51, 159, 209, 129, 164, 140, 130, 167, 16, 182, 133, 205, 126, 55, 237, 188, 89, 236},
+	},
+	{
+		testCaseId:          5,
+		hashStrategy:        md5.New,
+		hashStrategyName:    "md5",
+		defaultHashStrategy: false,
+		contents: []types.Content{
+			TestMD5Content{
+				x: "Hello",
+			},
+			TestMD5Content{
+				x: "Hi",
+			},
+			TestMD5Content{
+				x: "Hey",
+			},
+			TestMD5Content{
+				x: "Hola",
+			},
+		},
+		notInContents: TestMD5Content{x: "NotInTestTable"},
+		expectedHash:  []byte{217, 158, 206, 52, 191, 78, 253, 233, 25, 55, 69, 142, 254, 45, 127, 144},
+	},
+	{
+		testCaseId:          6,
+		hashStrategy:        md5.New,
+		hashStrategyName:    "md5",
+		defaultHashStrategy: false,
+		contents: []types.Content{
+			TestMD5Content{
+				x: "Hello",
+			},
+			TestMD5Content{
+				x: "Hi",
+			},
+			TestMD5Content{
+				x: "Hey",
+			},
+		},
+		notInContents: TestMD5Content{x: "NotInTestTable"},
+		expectedHash:  []byte{145, 228, 171, 107, 94, 219, 221, 171, 7, 195, 206, 128, 148, 98, 59, 76},
+	},
+	{
+		testCaseId:          7,
+		hashStrategy:        md5.New,
+		hashStrategyName:    "md5",
+		defaultHashStrategy: false,
+		contents: []types.Content{
+			TestMD5Content{
+				x: "Hello",
+			},
+			TestMD5Content{
+				x: "Hi",
+			},
+			TestMD5Content{
+				x: "Hey",
+			},
+			TestMD5Content{
+				x: "Greetings",
+			},
+			TestMD5Content{
+				x: "Hola",
+			},
+		},
+		notInContents: TestMD5Content{x: "NotInTestTable"},
+		expectedHash:  []byte{167, 200, 229, 62, 194, 247, 117, 12, 206, 194, 90, 235, 70, 14, 100, 100},
+	},
+	{
+		testCaseId:          8,
+		hashStrategy:        md5.New,
+		hashStrategyName:    "md5",
+		defaultHashStrategy: false,
+		contents: []types.Content{
+			TestMD5Content{
+				x: "123",
+			},
+			TestMD5Content{
+				x: "234",
+			},
+			TestMD5Content{
+				x: "345",
+			},
+			TestMD5Content{
+				x: "456",
+			},
+			TestMD5Content{
+				x: "1123",
+			},
+			TestMD5Content{
+				x: "2234",
+			},
+			TestMD5Content{
+				x: "3345",
+			},
+			TestMD5Content{
+				x: "4456",
+			},
+		},
+		notInContents: TestMD5Content{x: "NotInTestTable"},
+		expectedHash:  []byte{8, 36, 33, 50, 204, 197, 82, 81, 207, 74, 6, 60, 162, 209, 168, 21},
+	},
+	{
+		testCaseId:          9,
+		hashStrategy:        md5.New,
+		hashStrategyName:    "md5",
+		defaultHashStrategy: false,
+		contents: []types.Content{
+			TestMD5Content{
+				x: "123",
+			},
+			TestMD5Content{
+				x: "234",
+			},
+			TestMD5Content{
+				x: "345",
+			},
+			TestMD5Content{
+				x: "456",
+			},
+			TestMD5Content{
+				x: "1123",
+			},
+			TestMD5Content{
+				x: "2234",
+			},
+			TestMD5Content{
+				x: "3345",
+			},
+			TestMD5Content{
+				x: "4456",
+			},
+			TestMD5Content{
+				x: "5567",
+			},
+		},
+		notInContents: TestMD5Content{x: "NotInTestTable"},
+		expectedHash:  []byte{158, 85, 181, 191, 25, 250, 251, 71, 215, 22, 68, 68, 11, 198, 244, 148},
+	},
+}
+
+func TestNewTree(t *testing.T) {
+	for i := 0; i < len(table); i++ {
+		if !table[i].defaultHashStrategy {
+			continue
+		}
+		tree, err := types.NewTree(table[i].contents)
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		if bytes.Compare(tree.MerkleRoot(), table[i].expectedHash) != 0 {
+			t.Errorf("[case:%d] error: expected hash equal to %v got %v", table[i].testCaseId, table[i].expectedHash, tree.MerkleRoot())
+		}
+	}
+}
+
+func TestNewTreeWithHashingStrategy(t *testing.T) {
+	for i := 0; i < len(table); i++ {
+		tree, err := types.NewTreeWithHashStrategy(table[i].contents, table[i].hashStrategy)
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		if bytes.Compare(tree.MerkleRoot(), table[i].expectedHash) != 0 {
+			t.Errorf("[case:%d] error: expected hash equal to %v got %v", table[i].testCaseId, table[i].expectedHash, tree.MerkleRoot())
+		}
+	}
+}
+
+func TestMerkleTree_MerkleRoot(t *testing.T) {
+	for i := 0; i < len(table); i++ {
+		var tree *types.MerkleTree
+		var err error
+		if table[i].defaultHashStrategy {
+			tree, err = types.NewTree(table[i].contents)
+		} else {
+			tree, err = types.NewTreeWithHashStrategy(table[i].contents, table[i].hashStrategy)
+		}
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		if bytes.Compare(tree.MerkleRoot(), table[i].expectedHash) != 0 {
+			t.Errorf("[case:%d] error: expected hash equal to %v got %v", table[i].testCaseId, table[i].expectedHash, tree.MerkleRoot())
+		}
+	}
+}
+
+func TestMerkleTree_RebuildTree(t *testing.T) {
+	for i := 0; i < len(table); i++ {
+		var tree *types.MerkleTree
+		var err error
+		if table[i].defaultHashStrategy {
+			tree, err = types.NewTree(table[i].contents)
+		} else {
+			tree, err = types.NewTreeWithHashStrategy(table[i].contents, table[i].hashStrategy)
+		}
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		err = tree.RebuildTree()
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error:  %v", table[i].testCaseId, err)
+		}
+		if bytes.Compare(tree.MerkleRoot(), table[i].expectedHash) != 0 {
+			t.Errorf("[case:%d] error: expected hash equal to %v got %v", table[i].testCaseId, table[i].expectedHash, tree.MerkleRoot())
+		}
+	}
+}
+
+func TestMerkleTree_RebuildTreeWith(t *testing.T) {
+	for i := 0; i < len(table)-1; i++ {
+		if table[i].hashStrategyName != table[i+1].hashStrategyName {
+			continue
+		}
+		var tree *types.MerkleTree
+		var err error
+		if table[i].defaultHashStrategy {
+			tree, err = types.NewTree(table[i].contents)
+		} else {
+			tree, err = types.NewTreeWithHashStrategy(table[i].contents, table[i].hashStrategy)
+		}
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		err = tree.RebuildTreeWith(table[i+1].contents)
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		if bytes.Compare(tree.MerkleRoot(), table[i+1].expectedHash) != 0 {
+			t.Errorf("[case:%d] error: expected hash equal to %v got %v", table[i].testCaseId, table[i+1].expectedHash, tree.MerkleRoot())
+		}
+	}
+}
+
+/*func TestMerkleTree_VerifyTree(t *testing.T) {
+	for i := 0; i < len(table); i++ {
+		var tree *types.MerkleTree
+		var err error
+		if table[i].defaultHashStrategy {
+			tree, err = types.NewTree(table[i].contents)
+		} else {
+			tree, err = types.NewTreeWithHashStrategy(table[i].contents, table[i].hashStrategy)
+		}
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		v1, err := tree.VerifyTree()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v1 != true {
+			t.Errorf("[case:%d] error: expected tree to be valid", table[i].testCaseId)
+		}
+		tree.Root.Hash = []byte{1}
+		//tree.merkleRoot = []byte{1}
+		v2, err := tree.VerifyTree()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v2 != false {
+			t.Errorf("[case:%d] error: expected tree to be invalid", table[i].testCaseId)
+		}
+	}
+}*/
+
+func TestMerkleTree_VerifyContent(t *testing.T) {
+	for i := 0; i < len(table); i++ {
+		var tree *types.MerkleTree
+		var err error
+		if table[i].defaultHashStrategy {
+			tree, err = types.NewTree(table[i].contents)
+		} else {
+			tree, err = types.NewTreeWithHashStrategy(table[i].contents, table[i].hashStrategy)
+		}
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		if len(table[i].contents) > 0 {
+			v, err := tree.VerifyContent(table[i].contents[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !v {
+				t.Errorf("[case:%d] error: expected valid content", table[i].testCaseId)
+			}
+		}
+		if len(table[i].contents) > 1 {
+			v, err := tree.VerifyContent(table[i].contents[1])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !v {
+				t.Errorf("[case:%d] error: expected valid content", table[i].testCaseId)
+			}
+		}
+		if len(table[i].contents) > 2 {
+			v, err := tree.VerifyContent(table[i].contents[2])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !v {
+				t.Errorf("[case:%d] error: expected valid content", table[i].testCaseId)
+			}
+		}
+		if len(table[i].contents) > 0 {
+			tree.Root.Hash = []byte{1}
+			//tree.merkleRoot = []byte{1}
+			v, err := tree.VerifyContent(table[i].contents[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v {
+				t.Errorf("[case:%d] error: expected invalid content", table[i].testCaseId)
+			}
+			if err := tree.RebuildTree(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		v, err := tree.VerifyContent(table[i].notInContents)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v {
+			t.Errorf("[case:%d] error: expected invalid content", table[i].testCaseId)
+		}
+	}
+}
+
+func TestMerkleTree_String(t *testing.T) {
+	for i := 0; i < len(table); i++ {
+		var tree *types.MerkleTree
+		var err error
+		if table[i].defaultHashStrategy {
+			tree, err = types.NewTree(table[i].contents)
+		} else {
+			tree, err = types.NewTreeWithHashStrategy(table[i].contents, table[i].hashStrategy)
+		}
+		if err != nil {
+			t.Errorf("[case:%d] error: unexpected error: %v", table[i].testCaseId, err)
+		}
+		if tree.String() == "" {
+			t.Errorf("[case:%d] error: expected not empty string", table[i].testCaseId)
+		}
+	}
+}

--- a/torrentfs/types/types.go
+++ b/torrentfs/types/types.go
@@ -158,4 +158,3 @@ type FlowControlMeta struct {
 	BytesRequested uint64
 	IsCreate       bool
 }
-


### PR DESCRIPTION
For it will cost large compute to rebuild a mkt for file system to keep the state when the leaves number is too big. So we need to make a bandwidth for tree leaves to make sure the current root as the first leaf for next level tree. As above , we will only calculate mkt only using the leaves below the bandwidth and also keep the file system state.
This pr is under development for dev branch compare to add more features seriously.)