### PR TITLE
core/types: remove LogForStorage type 

### DIFF
--- a/core/types/gen_log_json.go
+++ b/core/types/gen_log_json.go
@@ -18,12 +18,12 @@ func (l Log) MarshalJSON() ([]byte, error) {
 		Address     common.Address `json:"address" gencodec:"required"`
 		Topics      []common.Hash  `json:"topics" gencodec:"required"`
 		Data        hexutil.Bytes  `json:"data" gencodec:"required"`
-		BlockNumber hexutil.Uint64 `json:"blockNumber"`
-		TxHash      common.Hash    `json:"transactionHash" gencodec:"required"`
-		TxIndex     hexutil.Uint   `json:"transactionIndex"`
-		BlockHash   common.Hash    `json:"blockHash"`
-		Index       hexutil.Uint   `json:"logIndex"`
-		Removed     bool           `json:"removed"`
+		BlockNumber hexutil.Uint64 `json:"blockNumber" rlp:"-"`
+		TxHash      common.Hash    `json:"transactionHash" gencodec:"required" rlp:"-"`
+		TxIndex     hexutil.Uint   `json:"transactionIndex" rlp:"-"`
+		BlockHash   common.Hash    `json:"blockHash" rlp:"-"`
+		Index       hexutil.Uint   `json:"logIndex" rlp:"-"`
+		Removed     bool           `json:"removed" rlp:"-"`
 	}
 	var enc Log
 	enc.Address = l.Address
@@ -44,12 +44,12 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 		Address     *common.Address `json:"address" gencodec:"required"`
 		Topics      []common.Hash   `json:"topics" gencodec:"required"`
 		Data        *hexutil.Bytes  `json:"data" gencodec:"required"`
-		BlockNumber *hexutil.Uint64 `json:"blockNumber"`
-		TxHash      *common.Hash    `json:"transactionHash" gencodec:"required"`
-		TxIndex     *hexutil.Uint   `json:"transactionIndex"`
-		BlockHash   *common.Hash    `json:"blockHash"`
-		Index       *hexutil.Uint   `json:"logIndex"`
-		Removed     *bool           `json:"removed"`
+		BlockNumber *hexutil.Uint64 `json:"blockNumber" rlp:"-"`
+		TxHash      *common.Hash    `json:"transactionHash" gencodec:"required" rlp:"-"`
+		TxIndex     *hexutil.Uint   `json:"transactionIndex" rlp:"-"`
+		BlockHash   *common.Hash    `json:"blockHash" rlp:"-"`
+		Index       *hexutil.Uint   `json:"logIndex" rlp:"-"`
+		Removed     *bool           `json:"removed" rlp:"-"`
 	}
 	var dec Log
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -17,11 +17,8 @@
 package types
 
 import (
-	"io"
-
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/common/hexutil"
-	"github.com/CortexFoundation/CortexTheseus/rlp"
 )
 
 //go:generate gencodec -type Log -field-override logMarshaling -out gen_log_json.go
@@ -40,19 +37,19 @@ type Log struct {
 	// Derived fields. These fields are filled in by the node
 	// but not secured by consensus.
 	// block in which the transaction was included
-	BlockNumber uint64 `json:"blockNumber"`
+	BlockNumber uint64 `json:"blockNumber" rlp:"-"`
 	// hash of the transaction
-	TxHash common.Hash `json:"transactionHash" gencodec:"required"`
+	TxHash common.Hash `json:"transactionHash" gencodec:"required" rlp:"-"`
 	// index of the transaction in the block
-	TxIndex uint `json:"transactionIndex"`
+	TxIndex uint `json:"transactionIndex" rlp:"-"`
 	// hash of the block in which the transaction was included
-	BlockHash common.Hash `json:"blockHash"`
-	// index of the log in the receipt
-	Index uint `json:"logIndex"`
+	BlockHash common.Hash `json:"blockHash" rlp:"-"`
+	// index of the log in the block
+	Index uint `json:"logIndex" rlp:"-"`
 
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.
-	Removed bool `json:"removed"`
+	Removed bool `json:"removed" rlp:"-"`
 }
 
 type logMarshaling struct {
@@ -60,73 +57,4 @@ type logMarshaling struct {
 	BlockNumber hexutil.Uint64
 	TxIndex     hexutil.Uint
 	Index       hexutil.Uint
-}
-
-type rlpLog struct {
-	Address common.Address
-	Topics  []common.Hash
-	Data    []byte
-}
-
-type rlpStorageLog struct {
-	Address     common.Address
-	Topics      []common.Hash
-	Data        []byte
-	BlockNumber uint64
-	TxHash      common.Hash
-	TxIndex     uint
-	BlockHash   common.Hash
-	Index       uint
-}
-
-// EncodeRLP implements rlp.Encoder.
-func (l *Log) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, rlpLog{Address: l.Address, Topics: l.Topics, Data: l.Data})
-}
-
-// DecodeRLP implements rlp.Decoder.
-func (l *Log) DecodeRLP(s *rlp.Stream) error {
-	var dec rlpLog
-	err := s.Decode(&dec)
-	if err == nil {
-		l.Address, l.Topics, l.Data = dec.Address, dec.Topics, dec.Data
-	}
-	return err
-}
-
-// LogForStorage is a wrapper around a Log that flattens and parses the entire content of
-// a log including non-consensus fields.
-type LogForStorage Log
-
-// EncodeRLP implements rlp.Encoder.
-func (l *LogForStorage) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, rlpStorageLog{
-		Address:     l.Address,
-		Topics:      l.Topics,
-		Data:        l.Data,
-		BlockNumber: l.BlockNumber,
-		TxHash:      l.TxHash,
-		TxIndex:     l.TxIndex,
-		BlockHash:   l.BlockHash,
-		Index:       l.Index,
-	})
-}
-
-// DecodeRLP implements rlp.Decoder.
-func (l *LogForStorage) DecodeRLP(s *rlp.Stream) error {
-	var dec rlpStorageLog
-	err := s.Decode(&dec)
-	if err == nil {
-		*l = LogForStorage{
-			Address:     dec.Address,
-			Topics:      dec.Topics,
-			Data:        dec.Data,
-			BlockNumber: dec.BlockNumber,
-			TxHash:      dec.TxHash,
-			TxIndex:     dec.TxIndex,
-			BlockHash:   dec.BlockHash,
-			Index:       dec.Index,
-		}
-	}
-	return err
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -87,7 +87,7 @@ type receiptRLP struct {
 type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
-	Logs              []*LogForStorage
+	Logs              []*Log
 }
 
 // v4StoredReceiptRLP is the storage encoding of a receipt used in database version 4.
@@ -96,7 +96,7 @@ type v4StoredReceiptRLP struct {
 	CumulativeGasUsed uint64
 	TxHash            common.Hash
 	ContractAddress   common.Address
-	Logs              []*LogForStorage
+	Logs              []*Log
 	GasUsed           uint64
 }
 
@@ -107,7 +107,7 @@ type v3StoredReceiptRLP struct {
 	Bloom             Bloom
 	TxHash            common.Hash
 	ContractAddress   common.Address
-	Logs              []*LogForStorage
+	Logs              []*Log
 	GasUsed           uint64
 }
 
@@ -188,10 +188,7 @@ func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 	enc := &storedReceiptRLP{
 		PostStateOrStatus: (*Receipt)(r).statusEncoding(),
 		CumulativeGasUsed: r.CumulativeGasUsed,
-		Logs:              make([]*LogForStorage, len(r.Logs)),
-	}
-	for i, log := range r.Logs {
-		enc.Logs[i] = (*LogForStorage)(log)
+		Logs:              r.Logs,
 	}
 	return rlp.Encode(w, enc)
 }
@@ -225,10 +222,7 @@ func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 		return err
 	}
 	r.CumulativeGasUsed = stored.CumulativeGasUsed
-	r.Logs = make([]*Log, len(stored.Logs))
-	for i, log := range stored.Logs {
-		r.Logs[i] = (*Log)(log)
-	}
+	r.Logs = stored.Logs
 	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
 
 	return nil

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -95,10 +95,10 @@ func encodeAsStoredReceiptRLP(want *Receipt) ([]byte, error) {
 	stored := &storedReceiptRLP{
 		PostStateOrStatus: want.statusEncoding(),
 		CumulativeGasUsed: want.CumulativeGasUsed,
-		Logs:              make([]*LogForStorage, len(want.Logs)),
+		Logs:              make([]*Log, len(want.Logs)),
 	}
 	for i, log := range want.Logs {
-		stored.Logs[i] = (*LogForStorage)(log)
+		stored.Logs[i] = (*Log)(log)
 	}
 	return rlp.EncodeToBytes(stored)
 }
@@ -109,11 +109,11 @@ func encodeAsV4StoredReceiptRLP(want *Receipt) ([]byte, error) {
 		CumulativeGasUsed: want.CumulativeGasUsed,
 		TxHash:            want.TxHash,
 		ContractAddress:   want.ContractAddress,
-		Logs:              make([]*LogForStorage, len(want.Logs)),
+		Logs:              make([]*Log, len(want.Logs)),
 		GasUsed:           want.GasUsed,
 	}
 	for i, log := range want.Logs {
-		stored.Logs[i] = (*LogForStorage)(log)
+		stored.Logs[i] = (*Log)(log)
 	}
 	return rlp.EncodeToBytes(stored)
 }
@@ -125,11 +125,11 @@ func encodeAsV3StoredReceiptRLP(want *Receipt) ([]byte, error) {
 		Bloom:             want.Bloom,
 		TxHash:            want.TxHash,
 		ContractAddress:   want.ContractAddress,
-		Logs:              make([]*LogForStorage, len(want.Logs)),
+		Logs:              make([]*Log, len(want.Logs)),
 		GasUsed:           want.GasUsed,
 	}
 	for i, log := range want.Logs {
-		stored.Logs[i] = (*LogForStorage)(log)
+		stored.Logs[i] = (*Log)(log)
 	}
 	return rlp.EncodeToBytes(stored)
 }

--- a/core/vm/cvm.go
+++ b/core/vm/cvm.go
@@ -133,7 +133,7 @@ type CVM struct {
 	// virtual machine configuration options used to initialise the
 	// cvm.
 	vmConfig Config
-	// global (to this context) ethereum virtual machine
+	// global (to this context) cortex virtual machine
 	// used throughout the execution of the tx.
 	interpreter *CVMInterpreter
 	// abort is used to abort the CVM calling operations

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -187,7 +187,6 @@ func (in *CVMInterpreter) IsInputMeta(code []byte) bool {
 func (in *CVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error) {
 
 	// Cortex code category solved
-	in.cvm.category = Category{}
 	in.cvm.category.IsCode, in.cvm.category.IsModel, in.cvm.category.IsInput = in.cvm.IsCode(contract.Code), in.cvm.IsModel(contract.Code), in.cvm.IsInput(contract.Code)
 
 	// Increment the call depth which is restricted to 1024


### PR DESCRIPTION
The encoding of Log and LogForStorage is exactly the same
now. After tracking it down it seems like #17106 changed the
storage schema of logs to be the same as the consensus
encoding.

Support for the legacy format was dropped in #22852 and if
I'm not wrong there's no reason anymore to have these two
equivalent types.

Since the RLP encoding simply contains the first three fields
of Log, we can also avoid creating a temporary struct for
encoding/decoding, and use the rlp:"-" tag in Log instead.

Note: this is an API change in core/types. We decided it's OK
to make this change because LogForStorage is an implementation
detail of go-ethereum and the type has zero uses outside of
package core/types.

Co-authored-by: Felix Lange <fjl@twurst.com>