### PR TITLE
core/rawdb: close database in test to avoid goroutine leak

### DIFF
--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -373,6 +373,7 @@ func TestAncientStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}
+	defer db.Close()
 	// Create a test block
 	block := types.NewBlockWithHeader(&types.Header{
 		Number:      big.NewInt(0),


### PR DESCRIPTION
* add db close to avoid goroutine leak

* core/rawdb: move close to defer

Co-authored-by: Martin Holst Swende <martin@swende.se>