### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/CortexFoundation/CortexTheseus/common/math"
 	"math/big"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
+	"github.com/CortexFoundation/CortexTheseus/common/math"
 	"github.com/CortexFoundation/CortexTheseus/crypto"
 )
 

--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -21,7 +21,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/big"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts"
@@ -45,7 +44,7 @@ var ErrNotAuthorized = errors.New("not authorized to sign this account")
 // Deprecated: Use NewTransactorWithChainID instead.
 func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
 	log.Warn("WARNING: NewTransactor has been deprecated in favour of NewTransactorWithChainID")
-	json, err := ioutil.ReadAll(keyin)
+	json, err := io.ReadAll(keyin)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +105,7 @@ func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 // NewTransactorWithChainID is a utility method to easily create a transaction signer from
 // an encrypted json key stream and the associated passphrase.
 func NewTransactorWithChainID(keyin io.Reader, passphrase string, chainID *big.Int) (*TransactOpts, error) {
-	json, err := ioutil.ReadAll(keyin)
+	json, err := io.ReadAll(keyin)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/abi/numbers_test.go
+++ b/accounts/abi/numbers_test.go
@@ -18,9 +18,10 @@ package abi
 
 import (
 	"bytes"
-	"github.com/CortexFoundation/CortexTheseus/common/math"
 	"math/big"
 	"testing"
+
+	"github.com/CortexFoundation/CortexTheseus/common/math"
 )
 
 func TestNumberTypes(t *testing.T) {

--- a/accounts/abi/topics_test.go
+++ b/accounts/abi/topics_test.go
@@ -1,11 +1,12 @@
 package abi
 
 import (
-	"github.com/CortexFoundation/CortexTheseus/common"
-	"github.com/CortexFoundation/CortexTheseus/crypto"
 	"math/big"
 	"reflect"
 	"testing"
+
+	"github.com/CortexFoundation/CortexTheseus/common"
+	"github.com/CortexFoundation/CortexTheseus/crypto"
 )
 
 func TestMakeTopics(t *testing.T) {

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -18,6 +18,9 @@ package external
 
 import (
 	"fmt"
+	"math/big"
+	"sync"
+
 	"github.com/CortexFoundation/CortexTheseus"
 	"github.com/CortexFoundation/CortexTheseus/accounts"
 	"github.com/CortexFoundation/CortexTheseus/common"
@@ -27,8 +30,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/log"
 	"github.com/CortexFoundation/CortexTheseus/rpc"
 	"github.com/CortexFoundation/CortexTheseus/signer/core"
-	"math/big"
-	"sync"
 )
 
 type ExternalBackend struct {

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -18,7 +18,6 @@ package keystore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -381,11 +380,11 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
-	// needed so that modTime of `file` is different to its current value after ioutil.WriteFile
+	// needed so that modTime of `file` is different to its current value after os.WriteFile
 	time.Sleep(1000 * time.Millisecond)
 
 	// Now replace file contents with crap
-	if err := ioutil.WriteFile(file, []byte("foo"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("foo"), 0644); err != nil {
 		t.Fatal(err)
 		return
 	}
@@ -398,9 +397,9 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 
 // forceCopyFile is like cp.CopyFile, but doesn't complain if the destination exists.
 func forceCopyFile(dst, src string) error {
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dst, data, 0644)
+	return os.WriteFile(dst, data, 0644)
 }

--- a/accounts/keystore/file_cache.go
+++ b/accounts/keystore/file_cache.go
@@ -17,7 +17,6 @@
 package keystore
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +40,7 @@ func (fc *fileCache) scan(keyDir string) (mapset.Set, mapset.Set, mapset.Set, er
 	t0 := time.Now()
 
 	// List all the failes from the keystore folder
-	files, err := ioutil.ReadDir(keyDir)
+	files, err := os.ReadDir(keyDir)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -55,7 +54,12 @@ func (fc *fileCache) scan(keyDir string) (mapset.Set, mapset.Set, mapset.Set, er
 	mods := mapset.NewThreadUnsafeSet()
 
 	var newLastMod time.Time
-	for _, fi := range files {
+	for _, file := range files {
+		fi, err := file.Info()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
 		path := filepath.Join(keyDir, fi.Name())
 		// Skip any non-key files from the folder
 		if nonKeyFile(fi) {

--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -197,7 +196,7 @@ func writeTemporaryKeyFile(file string, content []byte) (string, error) {
 	}
 	// Atomic write: create a temporary hidden file first
 	// then move it into place. TempFile assigns mode 0600.
-	f, err := ioutil.TempFile(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
+	f, err := os.CreateTemp(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
 	if err != nil {
 		return "", err
 	}

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -17,7 +17,6 @@
 package keystore
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
@@ -377,7 +376,7 @@ func checkEvents(t *testing.T, want []walletEvent, have []walletEvent) {
 }
 
 func tmpKeyStore(t *testing.T, encrypted bool) (string, *KeyStore) {
-	d, err := ioutil.TempDir("", "eth-keystore-test")
+	d, err := os.MkdirTemp("", "eth-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/keystore/passphrase.go
+++ b/accounts/keystore/passphrase.go
@@ -34,7 +34,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -82,7 +81,7 @@ type keyStorePassphrase struct {
 
 func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) (*Key, error) {
 	// Load the key from the keystore and decrypt its contents
-	keyjson, err := ioutil.ReadFile(filename)
+	keyjson, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/keystore/passphrase_test.go
+++ b/accounts/keystore/passphrase_test.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
@@ -30,7 +30,7 @@ const (
 
 // Tests that a json key file can be decrypted and encrypted in multiple rounds.
 func TestKeyEncryptDecrypt(t *testing.T) {
-	keyjson, err := ioutil.ReadFile("testdata/very-light-scrypt.json")
+	keyjson, err := os.ReadFile("testdata/very-light-scrypt.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/keystore/plain_test.go
+++ b/accounts/keystore/plain_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -32,7 +31,7 @@ import (
 )
 
 func tmpKeyStoreIface(t *testing.T, encrypted bool) (dir string, ks keyStore) {
-	d, err := ioutil.TempDir("", "cortex-keystore-test")
+	d, err := os.MkdirTemp("", "cortex-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/scwallet/hub.go
+++ b/accounts/scwallet/hub.go
@@ -34,7 +34,7 @@ package scwallet
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -96,7 +96,7 @@ func (hub *Hub) readPairings() error {
 		return err
 	}
 
-	pairingData, err := ioutil.ReadAll(pairingFile)
+	pairingData, err := io.ReadAll(pairingFile)
 	if err != nil {
 		return err
 	}

--- a/build/ci.go
+++ b/build/ci.go
@@ -49,7 +49,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -244,7 +243,7 @@ func doInstall(cmdline []string) {
 	goinstall.Args = append(goinstall.Args, packages...)
 	build.MustRun(goinstall)
 
-	if cmds, err := ioutil.ReadDir("cmd"); err == nil {
+	if cmds, err := os.ReadDir("cmd"); err == nil {
 		for _, cmd := range cmds {
 			pkgs, err := parser.ParseDir(token.NewFileSet(), filepath.Join(".", "cmd", cmd.Name()), nil, parser.PackageClauseOnly)
 			if err != nil {
@@ -579,7 +578,7 @@ func ppaUpload(workdir, ppa, sshUser string, files []string) {
 	if sshkey := getenvBase64("PPA_SSH_KEY"); len(sshkey) > 0 {
 		idfile = filepath.Join(workdir, "sshkey")
 		if _, err := os.Stat(idfile); os.IsNotExist(err) {
-			ioutil.WriteFile(idfile, sshkey, 0600)
+			os.WriteFile(idfile, sshkey, 0600)
 		}
 	}
 	// Upload
@@ -602,7 +601,7 @@ func makeWorkdir(wdflag string) string {
 	if wdflag != "" {
 		err = os.MkdirAll(wdflag, 0744)
 	} else {
-		wdflag, err = ioutil.TempDir("", "cortex-build-")
+		wdflag, err = os.MkdirTemp("", "cortex-build-")
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/build/update-license.go
+++ b/build/update-license.go
@@ -40,7 +40,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -242,7 +241,7 @@ func gitAuthors(files []string) []string {
 }
 
 func readAuthors() []string {
-	content, err := ioutil.ReadFile("AUTHORS")
+	content, err := os.ReadFile("AUTHORS")
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatalln("error reading AUTHORS:", err)
 	}
@@ -306,7 +305,7 @@ func writeAuthors(files []string) {
 		content.WriteString("\n")
 	}
 	fmt.Println("writing AUTHORS")
-	if err := ioutil.WriteFile("AUTHORS", content.Bytes(), 0644); err != nil {
+	if err := os.WriteFile("AUTHORS", content.Bytes(), 0644); err != nil {
 		log.Fatalln(err)
 	}
 }
@@ -382,7 +381,7 @@ func writeLicense(info *info) {
 	if err != nil {
 		log.Fatalf("error stat'ing %s: %v\n", info.file, err)
 	}
-	content, err := ioutil.ReadFile(info.file)
+	content, err := os.ReadFile(info.file)
 	if err != nil {
 		log.Fatalf("error reading %s: %v\n", info.file, err)
 	}
@@ -401,7 +400,7 @@ func writeLicense(info *info) {
 		return
 	}
 	fmt.Println("writing", info.ShortLicense(), info.file)
-	if err := ioutil.WriteFile(info.file, buf.Bytes(), fi.Mode()); err != nil {
+	if err := os.WriteFile(info.file, buf.Bytes(), fi.Mode()); err != nil {
 		log.Fatalf("error writing %s: %v", info.file, err)
 	}
 }

--- a/client/ctxc_client_test.go
+++ b/client/ctxc_client_test.go
@@ -19,6 +19,11 @@ package ctxcclient
 import (
 	"context"
 	"errors"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/CortexFoundation/CortexTheseus"
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo"
@@ -29,10 +34,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/ctxc"
 	"github.com/CortexFoundation/CortexTheseus/node"
 	"github.com/CortexFoundation/CortexTheseus/params"
-	"math/big"
-	"reflect"
-	"testing"
-	"time"
 )
 
 // Verify that Client implements the cortex interfaces.

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -154,9 +154,9 @@ func abigen(c *cli.Context) error {
 		)
 		input := c.GlobalString(abiFlag.Name)
 		if input == "-" {
-			abi, err = ioutil.ReadAll(os.Stdin)
+			abi, err = io.ReadAll(os.Stdin)
 		} else {
-			abi, err = ioutil.ReadFile(input)
+			abi, err = os.ReadFile(input)
 		}
 		if err != nil {
 			utils.Fatalf("Failed to read input ABI: %v", err)
@@ -165,7 +165,7 @@ func abigen(c *cli.Context) error {
 
 		var bin []byte
 		if binFile := c.GlobalString(binFlag.Name); binFile != "" {
-			if bin, err = ioutil.ReadFile(binFile); err != nil {
+			if bin, err = os.ReadFile(binFile); err != nil {
 				utils.Fatalf("Failed to read input bytecode: %v", err)
 			}
 			if strings.Contains(string(bin), "//") {
@@ -212,7 +212,7 @@ func abigen(c *cli.Context) error {
 			}
 
 		case c.GlobalIsSet(jsonFlag.Name):
-			jsonOutput, err := ioutil.ReadFile(c.GlobalString(jsonFlag.Name))
+			jsonOutput, err := os.ReadFile(c.GlobalString(jsonFlag.Name))
 			if err != nil {
 				utils.Fatalf("Failed to read combined-json from compiler: %v", err)
 			}
@@ -262,7 +262,7 @@ func abigen(c *cli.Context) error {
 		fmt.Printf("%s\n", code)
 		return nil
 	}
-	if err := ioutil.WriteFile(c.GlobalString(outFlag.Name), []byte(code), 0600); err != nil {
+	if err := os.WriteFile(c.GlobalString(outFlag.Name), []byte(code), 0600); err != nil {
 		utils.Fatalf("Failed to write ABI binding: %v", err)
 	}
 	return nil

--- a/cmd/cortex/accountcmd.go
+++ b/cmd/cortex/accountcmd.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts"
 	"github.com/CortexFoundation/CortexTheseus/accounts/keystore"
@@ -340,7 +340,7 @@ func importWallet(ctx *cli.Context) error {
 	if len(keyfile) == 0 {
 		utils.Fatalf("keyfile must be given as argument")
 	}
-	keyJSON, err := ioutil.ReadFile(keyfile)
+	keyJSON, err := os.ReadFile(keyfile)
 	if err != nil {
 		utils.Fatalf("Could not read wallet file: %v", err)
 	}

--- a/cmd/cortex/bugcmd.go
+++ b/cmd/cortex/bugcmd.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -30,7 +30,7 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/params"
 
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"
-	cli "gopkg.in/urfave/cli.v1"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var bugCommand = cli.Command{
@@ -76,7 +76,7 @@ func printOSDetails(w io.Writer) {
 	case "openbsd", "netbsd", "freebsd", "dragonfly":
 		printCmdOut(w, "uname -v: ", "uname", "-v")
 	case "solaris":
-		out, err := ioutil.ReadFile("/etc/release")
+		out, err := os.ReadFile("/etc/release")
 		if err == nil {
 			fmt.Fprintf(w, "/etc/release: %s\n", out)
 		} else {

--- a/cmd/cortex/config.go
+++ b/cmd/cortex/config.go
@@ -18,19 +18,17 @@ package main
 
 import (
 	"bufio"
-	//"bytes"
+	// "bytes"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	//"os/exec"
+	// "os/exec"
 	"reflect"
-	//"strconv"
+	// "strconv"
 	"strings"
-	//"time"
+	// "time"
 	"unicode"
-
-	cli "gopkg.in/urfave/cli.v1"
 
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"
 	"github.com/CortexFoundation/CortexTheseus/ctxc"
@@ -40,6 +38,7 @@ import (
 	whisper "github.com/CortexFoundation/CortexTheseus/whisper/whisperv6"
 	"github.com/CortexFoundation/torrentfs"
 	"github.com/naoina/toml"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var (

--- a/cmd/cortex/cvm.go
+++ b/cmd/cortex/cvm.go
@@ -17,9 +17,12 @@
 package main
 
 import (
-	gopsutil "github.com/shirou/gopsutil/mem"
+	"errors"
 	"math"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
+	"os/signal"
 	"os/user"
 	"path/filepath"
 	"runtime"
@@ -30,16 +33,13 @@ import (
 	"syscall"
 	"time"
 
-	"errors"
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"
 	"github.com/CortexFoundation/CortexTheseus/log"
 	"github.com/CortexFoundation/CortexTheseus/p2p"
 	"github.com/CortexFoundation/inference/synapse"
 	"github.com/CortexFoundation/torrentfs"
+	gopsutil "github.com/shirou/gopsutil/mem"
 	"gopkg.in/urfave/cli.v1"
-	"net/http"
-	_ "net/http/pprof"
-	"os/signal"
 )
 
 func homeDir() string {

--- a/cmd/cortex/cvm_infer_server.go
+++ b/cmd/cortex/cvm_infer_server.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
-	//"sync"
+	// "sync"
 
 	"github.com/CortexFoundation/inference"
-	//"github.com/CortexFoundation/CortexTheseus/rpc"
+	// "github.com/CortexFoundation/CortexTheseus/rpc"
 )
 
 //var rpcClient *rpc.Client
@@ -18,7 +18,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, rerr := ioutil.ReadAll(r.Body)
+	body, rerr := io.ReadAll(r.Body)
 	if rerr != nil {
 		RespErrorText(w, ErrRequestBodyRead)
 		return

--- a/cmd/cortex/genesis_test.go
+++ b/cmd/cortex/genesis_test.go
@@ -87,7 +87,7 @@ var customGenesisTests = []struct {
 //
 //		// Initialize the data directory with the custom genesis block
 //		json := filepath.Join(datadir, "genesis.json")
-//		if err := ioutil.WriteFile(json, []byte(tt.genesis), 0600); err != nil {
+//		if err := os.WriteFile(json, []byte(tt.genesis), 0600); err != nil {
 //			t.Fatalf("test %d: failed to write genesis file: %v", i, err)
 //		}
 //		runCtxc(t, "--datadir", datadir, "init", json).WaitExit()

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -19,6 +19,13 @@ package main
 
 import (
 	"fmt"
+	"math/big"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/CortexFoundation/CortexTheseus/accounts"
 	"github.com/CortexFoundation/CortexTheseus/accounts/keystore"
 	"github.com/CortexFoundation/CortexTheseus/client"
@@ -31,13 +38,7 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/node"
 	_ "github.com/CortexFoundation/statik"
 	"github.com/arsham/figurine/figurine"
-	cli "gopkg.in/urfave/cli.v1"
-	"math/big"
-	"os"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
+	"gopkg.in/urfave/cli.v1"
 )
 
 const (

--- a/cmd/cortex/misccmd.go
+++ b/cmd/cortex/misccmd.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"
-	cli "gopkg.in/urfave/cli.v1"
+	"gopkg.in/urfave/cli.v1"
 	// "github.com/CortexFoundation/CortexTheseus/consensus/cuckoo"
 	"github.com/CortexFoundation/CortexTheseus/ctxc"
 	"github.com/CortexFoundation/CortexTheseus/params"

--- a/cmd/cortex/run_test.go
+++ b/cmd/cortex/run_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -27,7 +26,7 @@ import (
 )
 
 func tmpdir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "cortex-test")
+	dir, err := os.MkdirTemp("", "cortex-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/cortex/usage.go
+++ b/cmd/cortex/usage.go
@@ -21,7 +21,6 @@ package main
 import (
 	"io"
 	"sort"
-
 	"strings"
 
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"

--- a/cmd/devp2p/dnscmd.go
+++ b/cmd/devp2p/dnscmd.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -30,7 +29,7 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/console"
 	"github.com/CortexFoundation/CortexTheseus/p2p/dnsdisc"
 	"github.com/CortexFoundation/CortexTheseus/p2p/enode"
-	cli "gopkg.in/urfave/cli.v1"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var (
@@ -227,7 +226,7 @@ func dnsToRoute53(ctx *cli.Context) error {
 
 // loadSigningKey loads a private key in Cortex keystore format.
 func loadSigningKey(keyfile string) *ecdsa.PrivateKey {
-	keyjson, err := ioutil.ReadFile(keyfile)
+	keyjson, err := os.ReadFile(keyfile)
 	if err != nil {
 		exit(fmt.Errorf("failed to read the keyfile at '%s': %v", keyfile, err))
 	}
@@ -356,7 +355,7 @@ func writeTreeMetadata(directory string, def *dnsDefinition) {
 		exit(err)
 	}
 	metaFile, _ := treeDefinitionFiles(directory)
-	if err := ioutil.WriteFile(metaFile, metaJSON, 0644); err != nil {
+	if err := os.WriteFile(metaFile, metaJSON, 0644); err != nil {
 		exit(err)
 	}
 }
@@ -385,7 +384,7 @@ func writeTXTJSON(file string, txt map[string]string) {
 		fmt.Println()
 		return
 	}
-	if err := ioutil.WriteFile(file, txtJSON, 0644); err != nil {
+	if err := os.WriteFile(file, txtJSON, 0644); err != nil {
 		exit(err)
 	}
 }

--- a/cmd/devp2p/enrcmd.go
+++ b/cmd/devp2p/enrcmd.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -52,9 +51,9 @@ func enrdump(ctx *cli.Context) error {
 		var b []byte
 		var err error
 		if file == "-" {
-			b, err = ioutil.ReadAll(os.Stdin)
+			b, err = io.ReadAll(os.Stdin)
 		} else {
-			b, err = ioutil.ReadFile(file)
+			b, err = os.ReadFile(file)
 		}
 		if err != nil {
 			return err

--- a/cmd/devp2p/nodeset.go
+++ b/cmd/devp2p/nodeset.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -66,7 +65,7 @@ func writeNodesJSON(file string, nodes nodeSet) {
 		os.Stdout.Write(nodesJSON)
 		return
 	}
-	if err := ioutil.WriteFile(file, nodesJSON, 0644); err != nil {
+	if err := os.WriteFile(file, nodesJSON, 0644); err != nil {
 		exit(err)
 	}
 }

--- a/cmd/keytools/batch_generate.go
+++ b/cmd/keytools/batch_generate.go
@@ -75,7 +75,7 @@ If you want to encrypt an existing private key, it can be specified by setting
 			}
 			//keyjson:= " " + common.ToHex(crypto.FromECDSAPub(&privateKey.PublicKey))
 			keyjson:= crypto.FromECDSAPub(&privateKey.PublicKey)
-			if err := ioutil.WriteFile(keyfilepath, keyjson, 0600); err != nil {
+			if err := os.WriteFile(keyfilepath, keyjson, 0600); err != nil {
 				utils.Fatalf("Failed to write keyfile to %s: %v", keyfilepath, err)
 			}*/
 		}

--- a/cmd/keytools/changepassphrase.go
+++ b/cmd/keytools/changepassphrase.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts/keystore"
@@ -29,7 +29,7 @@ Change the passphrase of a keyfile.`,
 		keyfilepath := ctx.Args().First()
 
 		// Read key from file.
-		keyjson, err := ioutil.ReadFile(keyfilepath)
+		keyjson, err := os.ReadFile(keyfilepath)
 		if err != nil {
 			utils.Fatalf("Failed to read the keyfile at '%s': %v", keyfilepath, err)
 		}
@@ -45,7 +45,7 @@ Change the passphrase of a keyfile.`,
 		fmt.Println("Please provide a new passphrase")
 		var newPhrase string
 		if passFile := ctx.String(newPassphraseFlag.Name); passFile != "" {
-			content, err := ioutil.ReadFile(passFile)
+			content, err := os.ReadFile(passFile)
 			if err != nil {
 				utils.Fatalf("Failed to read new passphrase file '%s': %v", passFile, err)
 			}
@@ -61,7 +61,7 @@ Change the passphrase of a keyfile.`,
 		}
 
 		// Then write the new keyfile in place of the old one.
-		if err := ioutil.WriteFile(keyfilepath, newJson, 600); err != nil {
+		if err := os.WriteFile(keyfilepath, newJson, 600); err != nil {
 			utils.Fatalf("Error writing new keyfile to disk: %v", err)
 		}
 

--- a/cmd/keytools/generate.go
+++ b/cmd/keytools/generate.go
@@ -19,7 +19,6 @@ package main
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -103,7 +102,7 @@ If you want to encrypt an existing private key, it can be specified by setting
 		if err := os.MkdirAll(filepath.Dir(keyfilepath), 0700); err != nil {
 			utils.Fatalf("Could not create directory %s", filepath.Dir(keyfilepath))
 		}
-		if err := ioutil.WriteFile(keyfilepath, keyjson, 0600); err != nil {
+		if err := os.WriteFile(keyfilepath, keyjson, 0600); err != nil {
 			utils.Fatalf("Failed to write keyfile to %s: %v", keyfilepath, err)
 		}
 

--- a/cmd/keytools/inspect.go
+++ b/cmd/keytools/inspect.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts/keystore"
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"
@@ -54,7 +54,7 @@ make sure to use this feature with great caution!`,
 		keyfilepath := ctx.Args().First()
 
 		// Read key from file.
-		keyjson, err := ioutil.ReadFile(keyfilepath)
+		keyjson, err := os.ReadFile(keyfilepath)
 		if err != nil {
 			utils.Fatalf("Failed to read the keyfile at '%s': %v", keyfilepath, err)
 		}

--- a/cmd/keytools/message.go
+++ b/cmd/keytools/message.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts/keystore"
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"
@@ -56,7 +56,7 @@ To sign a message contained in a file, use the --msgfile flag.
 
 		// Load the keyfile.
 		keyfilepath := ctx.Args().First()
-		keyjson, err := ioutil.ReadFile(keyfilepath)
+		keyjson, err := os.ReadFile(keyfilepath)
 		if err != nil {
 			utils.Fatalf("Failed to read the keyfile at '%s': %v", keyfilepath, err)
 		}
@@ -146,7 +146,7 @@ func getMessage(ctx *cli.Context, msgarg int) []byte {
 		if len(ctx.Args()) > msgarg {
 			utils.Fatalf("Can't use --msgfile and message argument at the same time.")
 		}
-		msg, err := ioutil.ReadFile(file)
+		msg, err := os.ReadFile(file)
 		if err != nil {
 			utils.Fatalf("Can't read message file: %v", err)
 		}

--- a/cmd/keytools/message_test.go
+++ b/cmd/keytools/message_test.go
@@ -17,14 +17,13 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestMessageSignVerify(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "ctxckey-test")
+	tmpdir, err := os.MkdirTemp("", "ctxckey-test")
 	if err != nil {
 		t.Fatal("Can't create temporary directory:", err)
 	}

--- a/cmd/keytools/utils.go
+++ b/cmd/keytools/utils.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"
@@ -56,7 +56,7 @@ func getPassphrase(ctx *cli.Context) string {
 	// Look for the --passwordfile flag.
 	passphraseFile := ctx.String(passphraseFlag.Name)
 	if passphraseFile != "" {
-		content, err := ioutil.ReadFile(passphraseFile)
+		content, err := os.ReadFile(passphraseFile)
 		if err != nil {
 			utils.Fatalf("Failed to read passphrase file '%s': %v",
 				passphraseFile, err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -20,12 +20,10 @@ package utils
 import (
 	"crypto/ecdsa"
 	"fmt"
-	gopsutil "github.com/shirou/gopsutil/mem"
-	"io/ioutil"
-	"os"
-
 	"math"
 	"math/big"
+	"net/url"
+	"os"
 	"path/filepath"
 	"runtime"
 	godebug "runtime/debug"
@@ -42,7 +40,8 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo"
 	"github.com/CortexFoundation/CortexTheseus/core"
 	whisper "github.com/CortexFoundation/CortexTheseus/whisper/whisperv6"
-	//"github.com/CortexFoundation/CortexTheseus/core/state"
+	gopsutil "github.com/shirou/gopsutil/mem"
+	// "github.com/CortexFoundation/CortexTheseus/core/state"
 	"github.com/CortexFoundation/CortexTheseus/core/vm"
 	"github.com/CortexFoundation/CortexTheseus/crypto"
 	"github.com/CortexFoundation/CortexTheseus/ctxc"
@@ -63,7 +62,6 @@ import (
 	"github.com/CortexFoundation/inference/synapse"
 	"github.com/CortexFoundation/torrentfs"
 	"gopkg.in/urfave/cli.v1"
-	"net/url"
 )
 
 var (
@@ -1099,7 +1097,7 @@ func MakePasswordList(ctx *cli.Context) []string {
 	if path == "" {
 		return nil
 	}
-	text, err := ioutil.ReadFile(path)
+	text, err := os.ReadFile(path)
 	if err != nil {
 		Fatalf("Failed to read password file: %v", err)
 	}

--- a/cmd/wnode/main.go
+++ b/cmd/wnode/main.go
@@ -28,11 +28,11 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/CortexFoundation/CortexTheseus/cmd/utils"
@@ -48,7 +48,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/whisper/mailserver"
 	whisper "github.com/CortexFoundation/CortexTheseus/whisper/whisperv6"
 	"golang.org/x/crypto/pbkdf2"
-	"sync"
 )
 
 const quitCommand = "~Q"
@@ -492,7 +491,7 @@ func sendFilesLoop() {
 			fmt.Println("Quit command received")
 			return
 		}
-		b, err := ioutil.ReadFile(s)
+		b, err := os.ReadFile(s)
 		if err != nil {
 			fmt.Printf(">>> Error: %s \n", err)
 		} else {
@@ -522,7 +521,7 @@ func fileReaderLoop() {
 			fmt.Println("Quit command received")
 			return
 		}
-		raw, err := ioutil.ReadFile(s)
+		raw, err := os.ReadFile(s)
 		if err != nil {
 			fmt.Printf(">>> Error: %s \n", err)
 		} else {
@@ -681,7 +680,7 @@ func writeMessageToFile(dir string, msg *whisper.ReceivedMessage, show bool) {
 	//}
 
 	fullpath := filepath.Join(dir, name)
-	err := ioutil.WriteFile(fullpath, env.Data, 0644)
+	err := os.WriteFile(fullpath, env.Data, 0644)
 	if err != nil {
 		fmt.Printf("\n%s {%x}: message received but not saved: %s\n", timestamp, address, err)
 	} else if show {

--- a/common/compiler/helpers.go
+++ b/common/compiler/helpers.go
@@ -19,7 +19,7 @@ package compiler
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"regexp"
 )
 
@@ -55,7 +55,7 @@ type ContractInfo struct {
 func slurpFiles(files []string) (string, error) {
 	var concat bytes.Buffer
 	for _, file := range files {
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		if err != nil {
 			return "", err
 		}

--- a/common/mclock/mclock.go
+++ b/common/mclock/mclock.go
@@ -19,7 +19,6 @@ package mclock
 
 import (
 	"time"
-
 	_ "unsafe" // for go:linkname
 )
 

--- a/common/test_utils.go
+++ b/common/test_utils.go
@@ -19,12 +19,12 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // LoadJSON reads the given file and unmarshals its content.
 func LoadJSON(file string, val interface{}) error {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/consensus/clique/api.go
+++ b/consensus/clique/api.go
@@ -18,6 +18,7 @@ package clique
 
 import (
 	"encoding/json"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/common/hexutil"
 	"github.com/CortexFoundation/CortexTheseus/consensus"

--- a/consensus/cuckoo/api.go
+++ b/consensus/cuckoo/api.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/CortexFoundation/CortexTheseus/log"
 
 	"github.com/CortexFoundation/CortexTheseus/common"

--- a/consensus/cuckoo/consensus.go
+++ b/consensus/cuckoo/consensus.go
@@ -18,13 +18,15 @@ package cuckoo
 
 import (
 	"encoding/binary"
-	//"encoding/hex"
-	//"bytes"
+	// "encoding/hex"
+	// "bytes"
 	"errors"
 	"fmt"
 	"math/big"
 	"runtime"
-	//"strconv"
+	"time"
+
+	// "strconv"
 	// "strings"
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/common/math"
@@ -40,7 +42,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/trie"
 	mapset "github.com/ucwong/golang-set"
 	"golang.org/x/crypto/sha3"
-	"time"
 	//	"github.com/CortexFoundation/CortexTheseus/solution/miner/libcuckoo"
 )
 

--- a/consensus/cuckoo/consensus_test.go
+++ b/consensus/cuckoo/consensus_test.go
@@ -2,10 +2,11 @@ package cuckoo
 
 import (
 	"encoding/binary"
-	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"math/big"
 	"math/rand"
 	"testing"
+
+	"github.com/CortexFoundation/CortexTheseus/core/types"
 )
 
 func TestReward(t *testing.T) {

--- a/consensus/cuckoo/cuckoo.go
+++ b/consensus/cuckoo/cuckoo.go
@@ -2,21 +2,22 @@ package cuckoo
 
 import (
 	"errors"
-	"github.com/CortexFoundation/CortexTheseus/common"
-	"github.com/CortexFoundation/CortexTheseus/common/mclock"
-	"github.com/CortexFoundation/CortexTheseus/consensus"
-	//"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo/plugins"
-	"github.com/CortexFoundation/CortexTheseus/core/types"
-	"github.com/CortexFoundation/CortexTheseus/log"
-	"github.com/CortexFoundation/CortexTheseus/metrics"
-	"github.com/CortexFoundation/CortexTheseus/rpc"
-	gopsutil "github.com/shirou/gopsutil/mem"
 	"math/big"
 	"math/rand"
 	"path/filepath"
 	"plugin"
 	"sync"
 	"time"
+
+	"github.com/CortexFoundation/CortexTheseus/common"
+	"github.com/CortexFoundation/CortexTheseus/common/mclock"
+	"github.com/CortexFoundation/CortexTheseus/consensus"
+	// "github.com/CortexFoundation/CortexTheseus/consensus/cuckoo/plugins"
+	"github.com/CortexFoundation/CortexTheseus/core/types"
+	"github.com/CortexFoundation/CortexTheseus/log"
+	"github.com/CortexFoundation/CortexTheseus/metrics"
+	"github.com/CortexFoundation/CortexTheseus/rpc"
+	gopsutil "github.com/shirou/gopsutil/mem"
 )
 
 var sharedCuckoo = New(Config{PowMode: ModeNormal})

--- a/consensus/cuckoo/cuckoo_faker.go
+++ b/consensus/cuckoo/cuckoo_faker.go
@@ -1,14 +1,15 @@
 package cuckoo
 
 import (
+	"math/big"
+	"time"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/consensus"
 	"github.com/CortexFoundation/CortexTheseus/core/state"
 	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"github.com/CortexFoundation/CortexTheseus/rpc"
 	"github.com/CortexFoundation/CortexTheseus/trie"
-	"math/big"
-	"time"
 )
 
 func NewFaker() *Cuckoo {

--- a/consensus/cuckoo/sealer_miner.go
+++ b/consensus/cuckoo/sealer_miner.go
@@ -4,10 +4,11 @@
 package cuckoo
 
 import (
-	//"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo/plugins"
+	"math/big"
+
+	// "github.com/CortexFoundation/CortexTheseus/consensus/cuckoo/plugins"
 	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"github.com/CortexFoundation/CortexTheseus/log"
-	"math/big"
 )
 
 func (cuckoo *Cuckoo) Mine(block *types.Block, id int, seed uint64, abort chan struct{}, found chan *types.Block) (err error) {

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -19,16 +19,15 @@ package console
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/CortexFoundation/CortexTheseus/common/hexutil"
-
-	"github.com/dop251/goja"
 	"io"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/CortexFoundation/CortexTheseus/common/hexutil"
 	"github.com/CortexFoundation/CortexTheseus/internal/jsre"
 	"github.com/CortexFoundation/CortexTheseus/rpc"
+	"github.com/dop251/goja"
 )
 
 // bridge is a collection of JavaScript utility methods to bride the .js runtime

--- a/console/console.go
+++ b/console/console.go
@@ -19,7 +19,6 @@ package console
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -140,7 +139,7 @@ func (c *Console) init(preload []string) error {
 
 	// Configure the input prompter for history and tab completion.
 	if c.prompter != nil {
-		if content, err := ioutil.ReadFile(c.histPath); err != nil {
+		if content, err := os.ReadFile(c.histPath); err != nil {
 			c.prompter.SetHistory(nil)
 		} else {
 			c.history = strings.Split(string(content), "\n")
@@ -475,7 +474,7 @@ func (c *Console) Execute(path string) error {
 
 // Stop cleans up the console and terminates the runtime environment.
 func (c *Console) Stop(graceful bool) error {
-	if err := ioutil.WriteFile(c.histPath, []byte(strings.Join(c.history, "\n")), 0600); err != nil {
+	if err := os.WriteFile(c.histPath, []byte(strings.Join(c.history, "\n")), 0600); err != nil {
 		return err
 	}
 	if err := os.Chmod(c.histPath, 0600); err != nil { // Force 0600, even if it was different previously

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -4,15 +4,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/CortexFoundation/CortexTheseus/common"
-	"github.com/CortexFoundation/CortexTheseus/core"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo"
+	"github.com/CortexFoundation/CortexTheseus/core"
 	"github.com/CortexFoundation/CortexTheseus/ctxc"
 	"github.com/CortexFoundation/CortexTheseus/internal/jsre"
 	"github.com/CortexFoundation/CortexTheseus/node"
@@ -69,7 +68,7 @@ type tester struct {
 // Please ensure you call Close() on the returned tester to avoid leaks.
 func newTester(t *testing.T, confOverride func(*ctxc.Config)) *tester {
 	// Create a temporary storage for the node keys and initialize it
-	workspace, err := ioutil.TempDir("", "console-tester-")
+	workspace, err := os.MkdirTemp("", "console-tester-")
 	if err != nil {
 		t.Fatalf("failed to create temporary keystore: %v", err)
 	}

--- a/core/asm/asm_test.go
+++ b/core/asm/asm_test.go
@@ -17,9 +17,8 @@
 package asm
 
 import (
-	"testing"
-
 	"encoding/hex"
+	"testing"
 )
 
 // Tests disassembling the instructions for valid evm code

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -18,6 +18,10 @@ package core
 
 import (
 	"crypto/ecdsa"
+	"math/big"
+	"os"
+	"testing"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/common/math"
 	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
@@ -26,10 +30,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/crypto"
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"github.com/CortexFoundation/CortexTheseus/params"
-	"io/ioutil"
-	"math/big"
-	"os"
-	"testing"
 )
 
 func BenchmarkInsertChain_empty_memdb(b *testing.B) {
@@ -150,7 +150,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 	if !disk {
 		db = rawdb.NewMemoryDatabase()
 	} else {
-		dir, err := ioutil.TempDir("", "eth-core-bench")
+		dir, err := os.MkdirTemp("", "eth-core-bench")
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
@@ -249,7 +249,7 @@ func makeChainForBench(db ctxcdb.Database, full bool, count uint64) {
 
 func benchWriteChain(b *testing.B, full bool, count uint64) {
 	for i := 0; i < b.N; i++ {
-		dir, err := ioutil.TempDir("", "eth-chain-bench")
+		dir, err := os.MkdirTemp("", "eth-chain-bench")
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
@@ -264,7 +264,7 @@ func benchWriteChain(b *testing.B, full bool, count uint64) {
 }
 
 func benchReadChain(b *testing.B, full bool, count uint64) {
-	dir, err := ioutil.TempDir("", "eth-chain-bench")
+	dir, err := os.MkdirTemp("", "eth-chain-bench")
 	if err != nil {
 		b.Fatalf("cannot create temporary directory: %v", err)
 	}

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -18,14 +18,15 @@ package core
 
 import (
 	_ "fmt"
+	"runtime"
+	"testing"
+	"time"
+
 	"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo"
 	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
 	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"github.com/CortexFoundation/CortexTheseus/core/vm"
 	"github.com/CortexFoundation/CortexTheseus/params"
-	"runtime"
-	"testing"
-	"time"
 )
 
 // Tests that simple header verification works, for both good and bad blocks.

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -17,6 +17,9 @@
 package core
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/consensus"
 	"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo"
@@ -26,8 +29,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/core/vm"
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"github.com/CortexFoundation/CortexTheseus/params"
-	"math/big"
-	"testing"
 )
 
 // So we can deterministically seed different blockchains

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -18,6 +18,9 @@ package core
 
 import (
 	"fmt"
+	"math/big"
+	"testing"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/consensus"
 	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
@@ -28,8 +31,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/params"
 	"github.com/CortexFoundation/CortexTheseus/rpc"
 	"github.com/CortexFoundation/CortexTheseus/trie"
-	"math/big"
-	"testing"
 )
 
 type CuckooFakeForTest struct {

--- a/core/helper_test.go
+++ b/core/helper_test.go
@@ -18,8 +18,8 @@ package core
 
 import (
 	"container/list"
-	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
 
+	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
 	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"github.com/CortexFoundation/CortexTheseus/event"

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -364,7 +363,7 @@ func checkReceiptsRLP(have, want types.Receipts) error {
 
 func TestAncientStorage(t *testing.T) {
 	// Freezer style fast import the chain.
-	frdir, err := ioutil.TempDir("", "")
+	frdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -17,6 +17,7 @@
 package rawdb
 
 import (
+	"hash"
 	"math/big"
 	"testing"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"github.com/CortexFoundation/CortexTheseus/rlp"
-	"hash"
 
 	"golang.org/x/crypto/sha3"
 )

--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -18,6 +18,7 @@ package rawdb
 
 import (
 	"encoding/binary"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"github.com/CortexFoundation/CortexTheseus/log"

--- a/core/rawdb/chain_iterator_test.go
+++ b/core/rawdb/chain_iterator_test.go
@@ -17,13 +17,14 @@
 package rawdb
 
 import (
-	"github.com/CortexFoundation/CortexTheseus/common"
-	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"math/big"
 	"reflect"
 	"sort"
 	"sync"
 	"testing"
+
+	"github.com/CortexFoundation/CortexTheseus/common"
+	"github.com/CortexFoundation/CortexTheseus/core/types"
 )
 
 func TestChainIterator(t *testing.T) {

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -256,7 +255,7 @@ func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 func newFreezerForTesting(t *testing.T, tables map[string]bool) (*freezer, string) {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "freezer")
+	dir, err := os.MkdirTemp("", "freezer")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/state/state_object_test.go
+++ b/core/state/state_object_test.go
@@ -2,8 +2,9 @@ package state
 
 import (
 	"bytes"
-	"github.com/CortexFoundation/CortexTheseus/common"
 	"testing"
+
+	"github.com/CortexFoundation/CortexTheseus/common"
 )
 
 func BenchmarkCutOriginal(b *testing.B) {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -18,11 +18,11 @@ package state
 
 import (
 	"bytes"
-	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
 	"math/big"
 	"testing"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
+	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
 	"github.com/CortexFoundation/CortexTheseus/crypto"
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	checker "gopkg.in/check.v1"

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -22,6 +22,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/big"
+	"sort"
+	"time"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
 	"github.com/CortexFoundation/CortexTheseus/core/state/snapshot"
@@ -31,9 +35,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/metrics"
 	"github.com/CortexFoundation/CortexTheseus/rlp"
 	"github.com/CortexFoundation/CortexTheseus/trie"
-	"math/big"
-	"sort"
-	"time"
 )
 
 type revision struct {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
 	"math"
 	"math/big"
 	"math/rand"
@@ -29,10 +28,10 @@ import (
 	"testing"
 	"testing/quick"
 
-	check "gopkg.in/check.v1"
-
 	"github.com/CortexFoundation/CortexTheseus/common"
+	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
 	"github.com/CortexFoundation/CortexTheseus/core/types"
+	"gopkg.in/check.v1"
 )
 
 // Tests that updating a state trie does not leak any database writes prior to

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -17,10 +17,11 @@
 package state
 
 import (
+	"sync"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/log"
 	"github.com/CortexFoundation/CortexTheseus/metrics"
-	"sync"
 )
 
 var (

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -18,6 +18,8 @@ package core
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/consensus"
 	"github.com/CortexFoundation/CortexTheseus/core/state"
@@ -25,7 +27,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/core/vm"
 	"github.com/CortexFoundation/CortexTheseus/crypto"
 	"github.com/CortexFoundation/CortexTheseus/params"
-	"math/big"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -19,7 +19,6 @@ package core
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -1754,7 +1753,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary journal: %v", err)
 	}

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -19,9 +19,6 @@ package types
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/CortexFoundation/CortexTheseus/common"
-	"github.com/CortexFoundation/CortexTheseus/params"
-	"github.com/CortexFoundation/CortexTheseus/rlp"
 	"hash"
 	"math/big"
 	"reflect"
@@ -29,8 +26,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/common/math"
 	"github.com/CortexFoundation/CortexTheseus/crypto"
+	"github.com/CortexFoundation/CortexTheseus/params"
+	"github.com/CortexFoundation/CortexTheseus/rlp"
 	"golang.org/x/crypto/sha3"
 )
 

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -2,14 +2,15 @@ package types
 
 import (
 	"bytes"
-	"github.com/CortexFoundation/CortexTheseus/common"
-	"github.com/CortexFoundation/CortexTheseus/crypto"
-	"github.com/CortexFoundation/CortexTheseus/params"
-	"github.com/CortexFoundation/CortexTheseus/rlp"
 	"math"
 	"math/big"
 	"reflect"
 	"testing"
+
+	"github.com/CortexFoundation/CortexTheseus/common"
+	"github.com/CortexFoundation/CortexTheseus/crypto"
+	"github.com/CortexFoundation/CortexTheseus/params"
+	"github.com/CortexFoundation/CortexTheseus/rlp"
 )
 
 func TestLegacyReceiptDecoding(t *testing.T) {

--- a/core/vm/cvm.go
+++ b/core/vm/cvm.go
@@ -18,11 +18,11 @@ package vm
 
 import (
 	_ "encoding/hex"
+	"fmt"
 	"math/big"
 	"sync/atomic"
 	"time"
 
-	"fmt"
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/common/hexutil"
 	"github.com/CortexFoundation/CortexTheseus/common/mclock"

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"errors"
+
 	"github.com/CortexFoundation/inference/synapse"
 )
 

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
@@ -258,7 +258,7 @@ func TestWriteExpectedValues(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_ = ioutil.WriteFile(fmt.Sprintf("testdata/testcases_%v.json", name), data, 0644)
+		_ = os.WriteFile(fmt.Sprintf("testdata/testcases_%v.json", name), data, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -268,7 +268,7 @@ func TestWriteExpectedValues(t *testing.T) {
 // TestJsonTestcases runs through all the testcases defined as json-files
 func TestJsonTestcases(t *testing.T) {
 	for name := range twoOpMethods {
-		data, err := ioutil.ReadFile(fmt.Sprintf("testdata/testcases_%v.json", name))
+		data, err := os.ReadFile(fmt.Sprintf("testdata/testcases_%v.json", name))
 		if err != nil {
 			t.Fatal("Failed to read file", err)
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"hash"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/common/math"
@@ -27,7 +28,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/params"
 	"github.com/CortexFoundation/inference/synapse"
 	torrentfs "github.com/CortexFoundation/torrentfs/types"
-	"sync/atomic"
 )
 
 var (

--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"errors"
 	"fmt"
+
 	"github.com/holiman/uint256"
 )
 

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts/abi"
 	"github.com/CortexFoundation/CortexTheseus/common"
@@ -30,7 +31,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"github.com/CortexFoundation/CortexTheseus/core/vm"
 	"github.com/CortexFoundation/CortexTheseus/params"
-	"time"
 )
 
 func TestDefaults(t *testing.T) {

--- a/crypto/bn256/cloudflare/lattice_test.go
+++ b/crypto/bn256/cloudflare/lattice_test.go
@@ -2,7 +2,6 @@ package bn256
 
 import (
 	"crypto/rand"
-
 	"testing"
 )
 

--- a/crypto/bn256/cloudflare/main_test.go
+++ b/crypto/bn256/cloudflare/main_test.go
@@ -1,9 +1,8 @@
 package bn256
 
 import (
-	"testing"
-
 	"crypto/rand"
+	"testing"
 )
 
 func TestRandomG2Marshal(t *testing.T) {

--- a/crypto/bn256/google/main_test.go
+++ b/crypto/bn256/google/main_test.go
@@ -1,9 +1,8 @@
 package bn256
 
 import (
-	"testing"
-
 	"crypto/rand"
+	"testing"
 )
 
 func TestRandomG2Marshal(t *testing.T) {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"os"
 
@@ -250,7 +249,7 @@ func checkKeyFileEnd(r *bufio.Reader) error {
 // restrictive permissions. The key data is saved hex-encoded.
 func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
 	k := hex.EncodeToString(FromECDSA(key))
-	return ioutil.WriteFile(file, []byte(k), 0600)
+	return os.WriteFile(file, []byte(k), 0600)
 }
 
 // GenerateKey generates a new private key

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -158,7 +157,7 @@ func TestLoadECDSAFile(t *testing.T) {
 		}
 	}
 
-	ioutil.WriteFile(fileName0, []byte(testPrivHex), 0600)
+	os.WriteFile(fileName0, []byte(testPrivHex), 0600)
 	defer os.Remove(fileName0)
 
 	key0, err := LoadECDSA(fileName0)

--- a/crypto/signify/signify.go
+++ b/crypto/signify/signify.go
@@ -20,15 +20,14 @@
 package signify
 
 import (
+	"crypto/ed25519"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
-
-	"crypto/ed25519"
 )
 
 var (
@@ -77,7 +76,7 @@ func SignifySignFile(input string, output string, key string, unTrustedComment s
 		return err
 	}
 
-	filedata, err := ioutil.ReadAll(in)
+	filedata, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/crypto/signify/signify_fuzz.go
+++ b/crypto/signify/signify_fuzz.go
@@ -22,11 +22,9 @@ package signify
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/jedisct1/go-minisign"
@@ -36,7 +34,7 @@ func Fuzz(data []byte) int {
 	if len(data) < 32 {
 		return -1
 	}
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +75,7 @@ func Fuzz(data []byte) int {
 
 	// Write the public key into the file to pass it as
 	// an argument to signify-openbsd
-	pubKeyFile, err := ioutil.TempFile("", "")
+	pubKeyFile, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -129,7 +127,7 @@ func getKey(fileS string) (string, error) {
 
 func createKeyPair() (string, string) {
 	// Create key and put it in correct format
-	tmpKey, err := ioutil.TempFile("", "")
+	tmpKey, err := os.CreateTemp("", "")
 	defer os.Remove(tmpKey.Name())
 	defer os.Remove(tmpKey.Name() + ".pub")
 	defer os.Remove(tmpKey.Name() + ".sec")

--- a/crypto/signify/signify_test.go
+++ b/crypto/signify/signify_test.go
@@ -20,7 +20,6 @@
 package signify
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -35,7 +34,7 @@ var (
 )
 
 func TestSignify(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +78,7 @@ func TestSignify(t *testing.T) {
 }
 
 func TestSignifyTrustedCommentTooManyLines(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +103,7 @@ func TestSignifyTrustedCommentTooManyLines(t *testing.T) {
 }
 
 func TestSignifyTrustedCommentTooManyLinesLF(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +128,7 @@ func TestSignifyTrustedCommentTooManyLinesLF(t *testing.T) {
 }
 
 func TestSignifyTrustedCommentEmpty(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ctxc/api_tracer.go
+++ b/ctxc/api_tracer.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -396,7 +396,7 @@ func (api *PrivateDebugAPI) TraceBlock(ctx context.Context, blob []byte, config 
 // TraceBlockFromFile returns the structured logs created during the execution of
 // CVM and returns them as a JSON object.
 func (api *PrivateDebugAPI) TraceBlockFromFile(ctx context.Context, file string, config *TraceConfig) ([]*txTraceResult, error) {
-	blob, err := ioutil.ReadFile(file)
+	blob, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("could not read file: %v", err)
 	}

--- a/ctxc/downloader/downloader_test.go
+++ b/ctxc/downloader/downloader_test.go
@@ -19,6 +19,13 @@ package downloader
 import (
 	"errors"
 	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
 	cortex "github.com/CortexFoundation/CortexTheseus"
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/core/rawdb"
@@ -26,12 +33,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"github.com/CortexFoundation/CortexTheseus/event"
 	"github.com/CortexFoundation/CortexTheseus/trie"
-	"math/big"
-	"strings"
-	"sync"
-	"sync/atomic"
-	"testing"
-	"time"
 )
 
 // Reduce some of the parameters to make the tester faster.

--- a/ctxc/downloader/testchain_test.go
+++ b/ctxc/downloader/testchain_test.go
@@ -18,6 +18,9 @@ package downloader
 
 import (
 	"fmt"
+	"math/big"
+	"sync"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo"
 	"github.com/CortexFoundation/CortexTheseus/core"
@@ -25,8 +28,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/core/types"
 	"github.com/CortexFoundation/CortexTheseus/crypto"
 	"github.com/CortexFoundation/CortexTheseus/params"
-	"math/big"
-	"sync"
 )
 
 // Test chain parameters.

--- a/ctxc/filters/filter_test.go
+++ b/ctxc/filters/filter_test.go
@@ -18,7 +18,6 @@ package filters
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -42,7 +41,7 @@ func makeReceipt(addr common.Address) *types.Receipt {
 }
 
 func BenchmarkFilters(b *testing.B) {
-	dir, err := ioutil.TempDir("", "filtertest")
+	dir, err := os.MkdirTemp("", "filtertest")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -96,7 +95,7 @@ func BenchmarkFilters(b *testing.B) {
 }
 
 func TestFilters(t *testing.T) {
-	dir, err := ioutil.TempDir("", "filtertest")
+	dir, err := os.MkdirTemp("", "filtertest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ctxc/helper_test.go
+++ b/ctxc/helper_test.go
@@ -22,6 +22,11 @@ package ctxc
 import (
 	"crypto/ecdsa"
 	"crypto/rand"
+	"math/big"
+	"sort"
+	"sync"
+	"testing"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/consensus/cuckoo"
 	"github.com/CortexFoundation/CortexTheseus/core"
@@ -37,10 +42,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/p2p"
 	"github.com/CortexFoundation/CortexTheseus/p2p/enode"
 	"github.com/CortexFoundation/CortexTheseus/params"
-	"math/big"
-	"sort"
-	"sync"
-	"testing"
 )
 
 var (

--- a/ctxc/peer.go
+++ b/ctxc/peer.go
@@ -19,6 +19,10 @@ package ctxc
 import (
 	"errors"
 	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/core/forkid"
 	"github.com/CortexFoundation/CortexTheseus/core/types"
@@ -26,9 +30,6 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/p2p"
 	"github.com/CortexFoundation/CortexTheseus/rlp"
 	mapset "github.com/ucwong/golang-set"
-	"math/big"
-	"sync"
-	"time"
 )
 
 var (

--- a/ctxc/sync_test.go
+++ b/ctxc/sync_test.go
@@ -17,13 +17,13 @@
 package ctxc
 
 import (
-	"github.com/CortexFoundation/CortexTheseus/p2p/enode"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/CortexFoundation/CortexTheseus/ctxc/downloader"
 	"github.com/CortexFoundation/CortexTheseus/p2p"
+	"github.com/CortexFoundation/CortexTheseus/p2p/enode"
 )
 
 //func TestFastSyncDisabling63(t *testing.T) { testFastSyncDisabling(t, 63) }

--- a/ctxc/tracers/tracer.go
+++ b/ctxc/tracers/tracer.go
@@ -30,7 +30,7 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/core/vm"
 	"github.com/CortexFoundation/CortexTheseus/crypto"
 	"github.com/CortexFoundation/CortexTheseus/log"
-	duktape "gopkg.in/olebedev/go-duktape.v3"
+	"gopkg.in/olebedev/go-duktape.v3"
 )
 
 // bigIntegerJS is the minified version of https://github.com/peterolson/BigInteger.js.

--- a/ctxcdb/dbtest/testsuite.go
+++ b/ctxcdb/dbtest/testsuite.go
@@ -2,10 +2,11 @@ package dbtest
 
 import (
 	"bytes"
-	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 )
 
 // TestDatabaseSuite runs a suite of tests against a KeyValueStore database

--- a/ctxcdb/leveldb/leveldb_test.go
+++ b/ctxcdb/leveldb/leveldb_test.go
@@ -17,11 +17,12 @@
 package leveldb
 
 import (
+	"testing"
+
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb/dbtest"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/storage"
-	"testing"
 )
 
 func TestLevelDB(t *testing.T) {

--- a/ctxcdb/memorydb/memorydb_test.go
+++ b/ctxcdb/memorydb/memorydb_test.go
@@ -17,9 +17,10 @@
 package memorydb
 
 import (
+	"testing"
+
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb"
 	"github.com/CortexFoundation/CortexTheseus/ctxcdb/dbtest"
-	"testing"
 )
 
 func TestMemoryDB(t *testing.T) {

--- a/internal/build/download.go
+++ b/internal/build/download.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -37,7 +36,7 @@ type ChecksumDB struct {
 
 // MustLoadChecksums loads a file containing checksums.
 func MustLoadChecksums(file string) *ChecksumDB {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatal("can't load checksum file: " + err.Error())
 	}

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -74,7 +73,7 @@ func RunGit(args ...string) string {
 
 // readGitFile returns content of file in .git directory.
 func readGitFile(file string) string {
-	content, err := ioutil.ReadFile(path.Join(".git", file))
+	content, err := os.ReadFile(path.Join(".git", file))
 	if err != nil {
 		return ""
 	}

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -170,7 +169,7 @@ func (tt *TestCmd) ExpectRegexp(regex string) (*regexp.Regexp, []string) {
 func (tt *TestCmd) ExpectExit() {
 	var output []byte
 	tt.withKillTimeout(func() {
-		output, _ = ioutil.ReadAll(tt.stdout)
+		output, _ = io.ReadAll(tt.stdout)
 	})
 	tt.WaitExit()
 	if tt.Cleanup != nil {

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -28,7 +28,7 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/metrics"
 	"github.com/CortexFoundation/CortexTheseus/metrics/exp"
 	"github.com/fjl/memsize/memsizeui"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 	"gopkg.in/urfave/cli.v1"
 )

--- a/internal/guide/guide_test.go
+++ b/internal/guide/guide_test.go
@@ -23,7 +23,6 @@
 package guide
 
 import (
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -37,7 +36,7 @@ import (
 // Tests that the account management snippets work correctly.
 func TestAccountManagement(t *testing.T) {
 	// Create a temporary folder to work with
-	workdir, err := ioutil.TempDir("", "")
+	workdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temporary work dir: %v", err)
 	}

--- a/internal/jsre/completion.go
+++ b/internal/jsre/completion.go
@@ -17,9 +17,10 @@
 package jsre
 
 import (
-	"github.com/dop251/goja"
 	"sort"
 	"strings"
+
+	"github.com/dop251/goja"
 )
 
 // CompleteKeywords returns potential continuations for the given line. Since line is

--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -22,8 +22,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
@@ -239,7 +239,7 @@ func (re *JSRE) Stop(waitForCallbacks bool) {
 // Exec(file) loads and runs the contents of a file
 // if a relative path is given, the jsre's assetPath is used
 func (re *JSRE) Exec(file string) error {
-	code, err := ioutil.ReadFile(common.AbsolutePath(re.assetPath, file))
+	code, err := os.ReadFile(common.AbsolutePath(re.assetPath, file))
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func (re *JSRE) Compile(filename string, src string) (err error) {
 func (re *JSRE) loadScript(call Call) (goja.Value, error) {
 	file := call.Argument(0).ToString().String()
 	file = common.AbsolutePath(re.assetPath, file)
-	source, err := ioutil.ReadFile(file)
+	source, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("Could not read file %s: %v", file, err)
 	}

--- a/internal/jsre/jsre_test.go
+++ b/internal/jsre/jsre_test.go
@@ -17,7 +17,6 @@
 package jsre
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -41,12 +40,12 @@ func (no *testNativeObjectBinding) TestMethod(call goja.FunctionCall) goja.Value
 }
 
 func newWithTestJS(t *testing.T, testjs string) (*JSRE, string) {
-	dir, err := ioutil.TempDir("", "jsre-test")
+	dir, err := os.MkdirTemp("", "jsre-test")
 	if err != nil {
 		t.Fatal("cannot create temporary directory:", err)
 	}
 	if testjs != "" {
-		if err := ioutil.WriteFile(path.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
+		if err := os.WriteFile(path.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
 			t.Fatal("cannot create test.js:", err)
 		}
 	}

--- a/metrics/librato/client.go
+++ b/metrics/librato/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -93,7 +93,7 @@ func (c *LibratoClient) PostMetrics(batch Batch) (err error) {
 
 	if resp.StatusCode != http.StatusOK {
 		var body []byte
-		if body, err = ioutil.ReadAll(resp.Body); err != nil {
+		if body, err = io.ReadAll(resp.Body); err != nil {
 			body = []byte(fmt.Sprintf("(could not fetch response body for error: %s)", err))
 		}
 		err = fmt.Errorf("unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -2,7 +2,7 @@ package metrics
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"sync"
 	"testing"
@@ -13,7 +13,7 @@ const FANOUT = 128
 
 // Stop the compiler from complaining during debugging.
 var (
-	_ = ioutil.Discard
+	_ = io.Discard
 	_ = log.LstdFlags
 )
 
@@ -78,7 +78,7 @@ func BenchmarkMetrics(b *testing.B) {
 					//log.Println("done Write")
 					return
 				default:
-					WriteOnce(r, ioutil.Discard)
+					WriteOnce(r, io.Discard)
 				}
 			}
 		}()

--- a/miner/unconfirmed_test.go
+++ b/miner/unconfirmed_test.go
@@ -16,9 +16,10 @@
 package miner
 
 import (
+	"testing"
+
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/core/types"
-	"testing"
 )
 
 // noopChainRetriever is an implementation of headerRetriever that always

--- a/node/config.go
+++ b/node/config.go
@@ -19,7 +19,6 @@ package node
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -468,7 +467,7 @@ func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
 	var ephemeral string
 	if keydir == "" {
 		// There is no datadir.
-		keydir, err = ioutil.TempDir("", "CortexTheseus-keystore")
+		keydir, err = os.MkdirTemp("", "CortexTheseus-keystore")
 		ephemeral = keydir
 	}
 

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,7 +31,7 @@ import (
 // ones or automatically generated temporary ones.
 func TestDatadirCreation(t *testing.T) {
 	// Create a temporary data dir and check that it can be used by a node
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create manual data dir: %v", err)
 	}
@@ -58,7 +57,7 @@ func TestDatadirCreation(t *testing.T) {
 		t.Fatalf("freshly created datadir not accessible: %v", err)
 	}
 	// Verify that an impossible datadir fails creation
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}
@@ -109,7 +108,7 @@ func TestIPCPathResolution(t *testing.T) {
 // ephemeral.
 func TestNodeKeyPersistency(t *testing.T) {
 	// Create a temporary folder and make sure no key is present
-	dir, err := ioutil.TempDir("", "node-test")
+	dir, err := os.MkdirTemp("", "node-test")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}
@@ -137,7 +136,7 @@ func TestNodeKeyPersistency(t *testing.T) {
 	if _, err = crypto.LoadECDSA(keyfile); err != nil {
 		t.Fatalf("failed to load freshly persisted node key: %v", err)
 	}
-	blob1, err := ioutil.ReadFile(keyfile)
+	blob1, err := os.ReadFile(keyfile)
 	if err != nil {
 		t.Fatalf("failed to read freshly persisted node key: %v", err)
 	}
@@ -145,7 +144,7 @@ func TestNodeKeyPersistency(t *testing.T) {
 	// Configure a new node and ensure the previously persisted key is loaded
 	config = &Config{Name: "unit-test", DataDir: dir}
 	config.NodeKey()
-	blob2, err := ioutil.ReadFile(filepath.Join(keyfile))
+	blob2, err := os.ReadFile(filepath.Join(keyfile))
 	if err != nil {
 		t.Fatalf("failed to read previously persisted node key: %v", err)
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -82,7 +81,7 @@ func TestNodeLifeCycle(t *testing.T) {
 // Tests that if the data dir is already in use, an appropriate error is returned.
 func TestNodeUsedDataDir(t *testing.T) {
 	// Create a temporary folder to use as the data directory
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -19,7 +19,6 @@ package node
 import (
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
@@ -100,7 +99,7 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 var gzPool = sync.Pool{
 	New: func() interface{} {
-		w := gzip.NewWriter(ioutil.Discard)
+		w := gzip.NewWriter(io.Discard)
 		return w
 	},
 }

--- a/node/service_test.go
+++ b/node/service_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 // the configured service context.
 func TestContextDatabases(t *testing.T) {
 	// Create a temporary folder and ensure no database is contained within
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/rand"
-
 	"net"
 	"reflect"
 	"testing"

--- a/p2p/discover/v5wire/encoding_test.go
+++ b/p2p/discover/v5wire/encoding_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -580,7 +579,7 @@ func (n *handshakeTestNode) id() enode.ID {
 // hexFile reads the given file and decodes the hex data contained in it.
 // Whitespace and any lines beginning with the # character are ignored.
 func hexFile(file string) []byte {
-	fileContent, err := ioutil.ReadFile(file)
+	fileContent, err := os.ReadFile(file)
 	if err != nil {
 		panic(err)
 	}

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync/atomic"
 	"time"
 
@@ -66,7 +65,7 @@ func (msg Msg) String() string {
 
 // Discard reads any remaining payload data into a black hole.
 func (msg Msg) Discard() error {
-	_, err := io.Copy(ioutil.Discard, msg.Payload)
+	_, err := io.Copy(io.Discard, msg.Payload)
 	return err
 }
 
@@ -245,7 +244,7 @@ func ExpectMsg(r MsgReader, code uint64, content interface{}) error {
 	if int(msg.Size) != len(contentEnc) {
 		return fmt.Errorf("message size mismatch: got %d, want %d", msg.Size, len(contentEnc))
 	}
-	actualContent, err := ioutil.ReadAll(msg.Payload)
+	actualContent, err := io.ReadAll(msg.Payload)
 	if err != nil {
 		return err
 	}

--- a/p2p/simulations/examples/ping-pong.go
+++ b/p2p/simulations/examples/ping-pong.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -62,7 +62,7 @@ func main() {
 		adapter = adapters.NewSimAdapter(services)
 
 	case "exec":
-		tmpdir, err := ioutil.TempDir("", "p2p-example")
+		tmpdir, err := os.MkdirTemp("", "p2p-example")
 		if err != nil {
 			log.Crit("error creating temp dir", "err", err)
 		}
@@ -159,7 +159,7 @@ func (p *pingPongService) Run(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 				errC <- err
 				return
 			}
-			payload, err := ioutil.ReadAll(msg.Payload)
+			payload, err := io.ReadAll(msg.Payload)
 			if err != nil {
 				errC <- err
 				return

--- a/p2p/simulations/http.go
+++ b/p2p/simulations/http.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -111,7 +110,7 @@ func (c *Client) SubscribeNetwork(events chan *Event, opts SubscribeOpts) (event
 		return nil, err
 	}
 	if res.StatusCode != http.StatusOK {
-		response, _ := ioutil.ReadAll(res.Body)
+		response, _ := io.ReadAll(res.Body)
 		res.Body.Close()
 		return nil, fmt.Errorf("unexpected HTTP status: %s: %s", res.Status, response)
 	}
@@ -251,7 +250,7 @@ func (c *Client) Send(method, path string, in, out interface{}) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-		response, _ := ioutil.ReadAll(res.Body)
+		response, _ := io.ReadAll(res.Body)
 		return fmt.Errorf("unexpected HTTP status: %s: %s", res.Status, response)
 	}
 	if out != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -17,10 +17,10 @@
 package params
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/big"
 
-	"encoding/binary"
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"golang.org/x/crypto/sha3"
 )

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"runtime"
 	"sync"
@@ -404,7 +403,7 @@ func TestEncodeToReader(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		return ioutil.ReadAll(r)
+		return io.ReadAll(r)
 	})
 }
 
@@ -445,7 +444,7 @@ func TestEncodeToReaderReturnToPool(t *testing.T) {
 		go func() {
 			for i := 0; i < 1000; i++ {
 				_, r, _ := EncodeToReader("foo")
-				ioutil.ReadAll(r)
+				io.ReadAll(r)
 				r.Read(buf)
 				r.Read(buf)
 				r.Read(buf)

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -17,9 +17,10 @@
 package rpc
 
 import (
-	"github.com/CortexFoundation/CortexTheseus/log"
 	"net"
 	"strings"
+
+	"github.com/CortexFoundation/CortexTheseus/log"
 )
 
 // StartIPCEndpoint starts an IPC endpoint.

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -171,7 +170,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", hc.url, ioutil.NopCloser(bytes.NewReader(body)))
+	req, err := http.NewRequestWithContext(ctx, "POST", hc.url, io.NopCloser(bytes.NewReader(body)))
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -20,8 +20,8 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -52,7 +52,7 @@ func TestServerRegisterName(t *testing.T) {
 }
 
 func TestServer(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata")
+	files, err := os.ReadDir("testdata")
 	if err != nil {
 		t.Fatal("where'd my testdata go?")
 	}
@@ -70,7 +70,7 @@ func TestServer(t *testing.T) {
 
 func runTestScript(t *testing.T, file string) {
 	server := newTestServer()
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/core/abihelper.go
+++ b/signer/core/abihelper.go
@@ -17,17 +17,15 @@
 package core
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
+	"regexp"
 	"strings"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts/abi"
 	"github.com/CortexFoundation/CortexTheseus/common"
-
-	"bytes"
-	"os"
-	"regexp"
 )
 
 type decodedArgument struct {
@@ -170,7 +168,7 @@ func NewEmptyAbiDB() (*AbiDb, error) {
 // NewAbiDBFromFile loads signature database from file, and
 // errors if the file is not valid json. Does no other validation of contents
 func NewAbiDBFromFile(path string) (*AbiDb, error) {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -189,14 +187,14 @@ func NewAbiDBFromFiles(standard, custom string) (*AbiDb, error) {
 	db := &AbiDb{make(map[string]string), make(map[string]string), custom}
 	db.customdbPath = custom
 
-	raw, err := ioutil.ReadFile(standard)
+	raw, err := os.ReadFile(standard)
 	if err != nil {
 		return nil, err
 	}
 	json.Unmarshal(raw, &db.db)
 	// Custom file may not exist. Will be created during save, if needed
 	if _, err := os.Stat(custom); err == nil {
-		raw, err = ioutil.ReadFile(custom)
+		raw, err = os.ReadFile(custom)
 		if err != nil {
 			return nil, err
 		}
@@ -235,7 +233,7 @@ func (db *AbiDb) saveCustomAbi(selector, signature string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(db.customdbPath, d, 0600)
+	err = os.WriteFile(db.customdbPath, d, 0600)
 	return err
 }
 

--- a/signer/core/abihelper_test.go
+++ b/signer/core/abihelper_test.go
@@ -17,11 +17,10 @@
 package core
 
 import (
-	"strings"
-	"testing"
-
 	"math/big"
 	"reflect"
+	"strings"
+	"testing"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts/abi"
 	"github.com/CortexFoundation/CortexTheseus/common"
@@ -210,7 +209,7 @@ func TestCalldataDecoding(t *testing.T) {
 //}
 //
 //func TestCustomABI(t *testing.T) {
-//	d, err := ioutil.TempDir("", "signer-4byte-test")
+//	d, err := os.MkdirTemp("", "signer-4byte-test")
 //	if err != nil {
 //		t.Fatal(err)
 //	}

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"reflect"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts"
@@ -444,7 +444,7 @@ func (api *SignerAPI) Export(ctx context.Context, addr common.Address) (json.Raw
 	if wallet.URL().Scheme != keystore.KeyStoreScheme {
 		return nil, fmt.Errorf("Account is not a keystore-account")
 	}
-	return ioutil.ReadFile(wallet.URL().Path)
+	return os.ReadFile(wallet.URL().Path)
 }
 
 // Import tries to import the given keyJSON in the local keystore. The keyJSON data is expected to be

--- a/signer/core/api_test.go
+++ b/signer/core/api_test.go
@@ -19,7 +19,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -105,7 +104,7 @@ func (ui *HeadlessUI) ShowInfo(message string) {
 }
 
 func tmpDirName(t *testing.T) string {
-	d, err := ioutil.TempDir("", "ctxc-keystore-test")
+	d, err := os.MkdirTemp("", "ctxc-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/core/auditlog.go
+++ b/signer/core/auditlog.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-
 	"encoding/json"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts"

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
 	"sync"
 
 	"github.com/CortexFoundation/CortexTheseus/common"

--- a/signer/core/types.go
+++ b/signer/core/types.go
@@ -18,9 +18,8 @@ package core
 
 import (
 	"encoding/json"
-	"strings"
-
 	"math/big"
+	"strings"
 
 	"github.com/CortexFoundation/CortexTheseus/accounts"
 	"github.com/CortexFoundation/CortexTheseus/common"

--- a/signer/storage/aes_gcm_storage.go
+++ b/signer/storage/aes_gcm_storage.go
@@ -23,7 +23,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/CortexFoundation/CortexTheseus/log"
@@ -101,7 +100,7 @@ func (s *AESEncryptedStorage) Get(key string) string {
 // readEncryptedStorage reads the file with encrypted creds
 func (s *AESEncryptedStorage) readEncryptedStorage() (map[string]storedCredential, error) {
 	creds := make(map[string]storedCredential)
-	raw, err := ioutil.ReadFile(s.filename)
+	raw, err := os.ReadFile(s.filename)
 
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -123,7 +122,7 @@ func (s *AESEncryptedStorage) writeEncryptedStorage(creds map[string]storedCrede
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(s.filename, raw, 0600); err != nil {
+	if err = os.WriteFile(s.filename, raw, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
@@ -61,7 +61,7 @@ func TestFileStorage(t *testing.T) {
 			CipherText: common.Hex2Bytes("2df87baf86b5073ef1f03e3cc738de75b511400f5465bb0ddeacf47ae4dc267d"),
 		},
 	}
-	d, err := ioutil.TempDir("", "ctxc-encrypted-storage-test")
+	d, err := os.MkdirTemp("", "ctxc-encrypted-storage-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestFileStorage(t *testing.T) {
 func TestEnd2End(t *testing.T) {
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(3), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
 
-	d, err := ioutil.TempDir("", "ctxc-encrypted-storage-test")
+	d, err := os.MkdirTemp("", "ctxc-encrypted-storage-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -1050,7 +1049,7 @@ func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts []
 }
 
 func tempDB() (string, *Database) {
-	dir, err := ioutil.TempDir("", "trie-bench")
+	dir, err := os.MkdirTemp("", "trie-bench")
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory: %v", err))
 	}

--- a/whisper/mailserver/mailserver.go
+++ b/whisper/mailserver/mailserver.go
@@ -20,7 +20,6 @@ package mailserver
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/syndtr/goleveldb/leveldb/errors"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/crypto"
@@ -28,6 +27,7 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/rlp"
 	whisper "github.com/CortexFoundation/CortexTheseus/whisper/whisperv6"
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )

--- a/whisper/mailserver/server_test.go
+++ b/whisper/mailserver/server_test.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"encoding/binary"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -83,7 +83,7 @@ func TestMailServer(t *testing.T) {
 	const password = "password_for_this_test"
 	const dbPath = "whisper-server-test"
 
-	dir, err := ioutil.TempDir("", dbPath)
+	dir, err := os.MkdirTemp("", dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since Cortex has been upgraded to Go 1.17, this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.