### PR TITLE
common/hexutil: improve performance of EncodeBig

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -176,13 +176,14 @@ func MustDecodeBig(input string) *big.Int {
 }
 
 // EncodeBig encodes bigint as a hex string with 0x prefix.
-// The sign of the integer is ignored.
 func EncodeBig(bigint *big.Int) string {
-	nbits := bigint.BitLen()
-	if nbits == 0 {
+	if sign := bigint.Sign(); sign == 0 {
 		return "0x0"
+	} else if sign > 0 {
+		return "0x" + bigint.Text(16)
+	} else {
+		return "-0x" + bigint.Text(16)[1:]
 	}
-	return fmt.Sprintf("%#x", bigint)
 }
 
 func has0xPrefix(input string) bool {

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -205,3 +205,15 @@ func TestDecodeUint64(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkEncodeBig(b *testing.B) {
+	for _, bench := range encodeBigTests {
+		b.Run(bench.want, func(b *testing.B) {
+			b.ReportAllocs()
+			bigint := bench.input.(*big.Int)
+			for i := 0; i < b.N; i++ {
+				EncodeBig(bigint)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- use Text instead of fmt.Sprintf
- reduced allocs from 6 to 2
- improved speed