### PR TITLE
core/asm: change order of items in stringtokenTypes

### DIFF
--- a/core/asm/lexer.go
+++ b/core/asm/lexer.go
@@ -68,10 +68,10 @@ func (it tokenType) String() string {
 
 var stringtokenTypes = []string{
 	eof:              "EOF",
+	lineStart:        "new line",
+	lineEnd:          "end of line",
 	invalidStatement: "invalid statement",
 	element:          "element",
-	lineEnd:          "end of line",
-	lineStart:        "new line",
 	label:            "label",
 	labelDef:         "label definition",
 	number:           "number",


### PR DESCRIPTION
This orders the items in slice definition same as the enum values.