### PR TITLE
p2p: fix type of DiscSubprotocolError 

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -69,7 +69,7 @@ const (
 	DiscUnexpectedIdentity
 	DiscSelf
 	DiscReadTimeout
-	DiscSubprotocolError = 0x10
+	DiscSubprotocolError = DiscReason(0x10)
 )
 
 var discReasonToString = [...]string{


### PR DESCRIPTION
It was 'int' accidentally, should be DiscReason instead.