### PR TITLE
trie: fix size accounting in cleaner

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -809,7 +809,7 @@ func (c *cleaner) Put(key []byte, rlp []byte) error {
 	delete(c.db.dirties, hash)
 	c.db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
 	if node.children != nil {
-		c.db.dirtiesSize -= common.StorageSize(cachedNodeChildrenSize + len(node.children)*(common.HashLength+2))
+		c.db.childrenSize -= common.StorageSize(cachedNodeChildrenSize + len(node.children)*(common.HashLength+2))
 	}
 	// Move the flushed node into the clean cache to prevent insta-reloads
 	if c.db.cleans != nil {


### PR DESCRIPTION
Decrease children size instead of dirties size when marking dirties as cleaned up in trie cleaner