### PR TITLE
core: remove lock in BlockChain.ExportN

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -712,22 +712,25 @@ func (bc *BlockChain) Export(w io.Writer) error {
 
 // ExportN writes a subset of the active chain to the given writer.
 func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
-	if !bc.chainmu.TryLock() {
-		return errChainStopped
-	}
-	defer bc.chainmu.Unlock()
-
 	if first > last {
 		return fmt.Errorf("export failed: first (%d) is greater than last (%d)", first, last)
 	}
 	log.Info("Exporting batch of blocks", "count", last-first+1)
 
-	start, reported := time.Now(), time.Now()
+	var (
+		parentHash common.Hash
+		start      = time.Now()
+		reported   = time.Now()
+	)
 	for nr := first; nr <= last; nr++ {
 		block := bc.GetBlockByNumber(nr)
 		if block == nil {
 			return fmt.Errorf("export failed on #%d: not found", nr)
 		}
+		if nr > first && block.ParentHash() != parentHash {
+			return fmt.Errorf("export failed: chain reorg during export")
+		}
+		parentHash = block.Hash()
 		if err := block.EncodeRLP(w); err != nil {
 			return err
 		}


### PR DESCRIPTION
* Remove locking in (*BlockChain).ExportN

Since ExportN is read-only, it shouldn't need the lock. (?)

* Add hash check to detect reorgs during export.

* fix check order

* Update blockchain.go

* Update blockchain.go

Co-authored-by: rjl493456442 <garyrong0905@gmail.com>