### PR TITLE
all: assign zero after resize in implementations of heap.Interface 

### DIFF
--- a/core/txpool/list.go
+++ b/core/txpool/list.go
@@ -44,6 +44,7 @@ func (h *nonceHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]
+	old[n-1] = 0
 	*h = old[0 : n-1]
 	return x
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -351,6 +351,7 @@ func (s *TxByPriceAndTime) Pop() interface{} {
 	old := *s
 	n := len(old)
 	x := old[n-1]
+	old[n-1] = nil
 	*s = old[0 : n-1]
 	return x
 }

--- a/p2p/util.go
+++ b/p2p/util.go
@@ -70,6 +70,7 @@ func (h *expHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]
+	old[n-1] = expItem{}
 	*h = old[0 : n-1]
 	return x
 }


### PR DESCRIPTION
This changes the Pop method to assign the zero value before reducing slice size. Doing so ensures the backing array does not reference removed item values.