### PR TITLE
build: add support for Ubuntu 22.10 (Kinetic Kudu) 

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -129,18 +129,19 @@ var (
 	// Distros for which packages are created.
 	// Note: vivid is unsupported because there is no golang-1.6 package for it.
 	// Note: the following Ubuntu releases have been officially deprecated on Launchpad:
-	//   wily, yakkety, zesty, artful, cosmic, disco, eoan, groovy, hirsuite
+	//   wily, yakkety, zesty, artful, cosmic, disco, eoan, groovy, hirsuite, impish
 	debDistroGoBoots = map[string]string{
-		"trusty": "golang-1.18.1", // EOL: 04/2024
-		"xenial": "golang-go",     // EOL: 04/2026
-		"bionic": "golang-go",     // EOL: 04/2028
-		"focal":  "golang-go",     // EOL: 04/2030
-		"impish": "golang-go",     // EOL: 07/2022
-		// "jammy": "golang-go",   // EOL: 04/2027
+		"trusty":  "golang-1.19.4", // EOL: 04/2024
+		"xenial":  "golang-go",     // EOL: 04/2026
+		"bionic":  "golang-go",     // EOL: 04/2028
+		"focal":   "golang-go",     // EOL: 04/2030
+		"jammy":   "golang-go",     // EOL: 04/2032
+		"kinetic": "golang-go",     // EOL: 07/2023
+		//"lunar": "golang-go",  // EOL: 01/2024
 	}
 
 	debGoBootPaths = map[string]string{
-		"golang-1.18.1": "/usr/lib/go-1.18.1",
+		"golang-1.19.4": "/usr/lib/go-1.19.4",
 		"golang-go":     "/usr/lib/go",
 	}
 


### PR DESCRIPTION
Adds uploads to Kinetic in Launchpad, and removes the upload for 21.10 impish (not supported since July)