### PR TITLE
core/rawdb: fsync head data file before closing it

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -86,15 +86,15 @@ func (f *chainFreezer) Close() error {
 // This functionality is deliberately broken off from block importing to avoid
 // incurring additional data shuffling delays on block propagation.
 func (f *chainFreezer) freeze(db ctxcdb.KeyValueStore) {
-	nfdb := &nofreezedb{KeyValueStore: db}
-
 	var (
 		backoff   bool
 		triggered chan struct{} // Used in tests
+		nfdb      = &nofreezedb{KeyValueStore: db}
 	)
 
 	timer := time.NewTimer(freezerRecheckInterval)
 	defer timer.Stop()
+
 	for {
 		select {
 		case <-f.quit:

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -860,8 +860,11 @@ func (t *freezerTable) advanceHead() error {
 	if err != nil {
 		return err
 	}
-
-	// Close old file, and reopen in RDONLY mode.
+	// Commit the contents of the old file to stable storage and
+	// tear it down. It will be re-opened in read-only mode.
+	if err := t.head.Sync(); err != nil {
+		return err
+	}
 	t.releaseFile(t.headId)
 	t.openFile(t.headId, openFreezerFileForReadOnly)
 

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -194,7 +194,7 @@ func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 
 	var item = make([]byte, 256)
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 10; i++ {
 		// First reset and write 100 items.
 		if err := f.TruncateHead(0); err != nil {
 			t.Fatal("truncate failed:", err)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.1
 	github.com/CortexFoundation/inference v1.0.2-0.20221114235728-985486629a61
 	github.com/CortexFoundation/statik v0.0.0-20210315012922-8bb8a7b5dc66
-	github.com/CortexFoundation/torrentfs v1.0.35-0.20230112224026-33d896151830
+	github.com/CortexFoundation/torrentfs v1.0.35-0.20230114014057-c7a532b00dfd
 	github.com/VictoriaMetrics/fastcache v1.12.0
 	github.com/arsham/figurine v1.3.0
 	github.com/aws/aws-sdk-go-v2 v1.17.3

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/CortexFoundation/statik v0.0.0-20210315012922-8bb8a7b5dc66/go.mod h1:
 github.com/CortexFoundation/torrentfs v1.0.13-0.20200623060705-ce027f43f2f8/go.mod h1:Ma+tGhPPvz4CEZHaqEJQMOEGOfHeQBiAoNd1zyc/w3Q=
 github.com/CortexFoundation/torrentfs v1.0.14-0.20200703071639-3fcabcabf274/go.mod h1:qnb3YlIJmuetVBtC6Lsejr0Xru+1DNmDCdTqnwy7lhk=
 github.com/CortexFoundation/torrentfs v1.0.20-0.20200810031954-d36d26f82fcc/go.mod h1:N5BsicP5ynjXIi/Npl/SRzlJ630n1PJV2sRj0Z0t2HA=
-github.com/CortexFoundation/torrentfs v1.0.35-0.20230112224026-33d896151830 h1:HMwK8zr9r6NGcdlLH216FkKs3y42jytYR6bPASY2VQQ=
-github.com/CortexFoundation/torrentfs v1.0.35-0.20230112224026-33d896151830/go.mod h1:pzLgyzw0Su0ekjYCfTQ3T8aoTCpYULhbV7exUyUpV6w=
+github.com/CortexFoundation/torrentfs v1.0.35-0.20230114014057-c7a532b00dfd h1:Xg3SGG6slPdNSpP+ALcMmlU2+2PPnEk4eMQZycCaftA=
+github.com/CortexFoundation/torrentfs v1.0.35-0.20230114014057-c7a532b00dfd/go.mod h1:pzLgyzw0Su0ekjYCfTQ3T8aoTCpYULhbV7exUyUpV6w=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0 h1:6dpdDPTRoo78HxAJ6T1HfMiKSnqhgRRqzCuPshRkQ7I=

--- a/vendor/github.com/CortexFoundation/torrentfs/Makefile
+++ b/vendor/github.com/CortexFoundation/torrentfs/Makefile
@@ -18,6 +18,7 @@ all:
 	go build -v -o $(GOBIN)/torrent-magnet cmd/torrent-magnet/*.go
 	go build -v -o $(GOBIN)/seeding cmd/seeding/*.go
 	go build -v -o $(GOBIN)/server cmd/server/*.go
+	go build -v -o $(GOBIN)/pack-blocklist cmd/pack-blocklist/*.go
 clean:
 	go clean -cache
 	rm -rf $(GOBIN)/*

--- a/vendor/github.com/CortexFoundation/torrentfs/backend/handler.go
+++ b/vendor/github.com/CortexFoundation/torrentfs/backend/handler.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	//"math"
 	"os"
 	"path/filepath"
@@ -556,10 +557,11 @@ func NewTorrentManager(config *params.Config, fsid uint64, cache, compress bool)
 	cfg.DisableTCP = config.DisableTCP
 	cfg.DisableIPv6 = config.DisableIPv6
 
-	if blocklist, err := iplist.MMapPackedFile("packed-blocklist"); err != nil {
-		log.Warn("black list load err", "err", err)
-	} else {
-		//defer blocklist.Close()
+	cfg.IPBlocklist = iplist.New([]iplist.Range{
+		iplist.Range{First: net.ParseIP("10.0.0.1"), Last: net.ParseIP("10.0.0.255")}})
+
+	if blocklist, err := iplist.MMapPackedFile("packed-blocklist"); err == nil {
+		log.Info("Block list loaded")
 		cfg.IPBlocklist = blocklist
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/CortexFoundation/merkletree
 # github.com/CortexFoundation/statik v0.0.0-20210315012922-8bb8a7b5dc66
 ## explicit; go 1.16
 github.com/CortexFoundation/statik
-# github.com/CortexFoundation/torrentfs v1.0.35-0.20230112224026-33d896151830
+# github.com/CortexFoundation/torrentfs v1.0.35-0.20230114014057-c7a532b00dfd
 ## explicit; go 1.19
 github.com/CortexFoundation/torrentfs
 github.com/CortexFoundation/torrentfs/backend


### PR DESCRIPTION
This PR fixes an issue which might result in data lost in freezer.

Whenever mutation happens in freezer, all data will be written into head data file and it will be rotated with a new one in case the size of file reaches the threshold.

Theoretically, the rotated old data file should be fsync'd to prevent data loss. In freezer.Sync function, we only fsync: (1) index file (2) meta file and (3) head data file. So this PR forcibly fsync the head data file if mutation happens in the boundary of data file.