### PR TITLE
core: add Timestamp method in BlockGen (#26844)

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -136,6 +136,11 @@ func (b *BlockGen) Number() *big.Int {
 	return new(big.Int).Set(b.header.Number)
 }
 
+// Timestamp returns the timestamp of the block being generated.
+func (b *BlockGen) Timestamp() uint64 {
+	return b.header.Time
+}
+
 // AddUncheckedReceipt forcefully adds a receipts to the block without a
 // backing transaction.
 //


### PR DESCRIPTION
Since forks are now scheduled by block time, it can be necessary to check the timestamp of a block while generating transactions.