### PR TITLE
core/txpool: allow future local transactions

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -686,7 +686,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			return false, ErrTxPoolOverflow
 		}
 		// If the new transaction is a future transaction it should never churn pending transactions
-		if pool.isFuture(from, tx) {
+		if !isLocal && pool.isFuture(from, tx) {
 			var replacesPending bool
 			for _, dropTx := range drop {
 				dropSender, _ := types.Sender(pool.signer, dropTx)


### PR DESCRIPTION
Local transactions should not be subject to the "future shouldn't churn pending txs" rule