### PR TITLE
core/txpool: use atomic int added in go1.19 

### DIFF
--- a/core/txpool/list.go
+++ b/core/txpool/list.go
@@ -481,7 +481,7 @@ type pricedList struct {
 	// This field is accessed atomically, and must be the first field
 	// to ensure it has correct alignment for atomic.AddInt64.
 	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
-	stales           int64
+	stales           atomic.Int64
 	all              *lookup    // Pointer to the map of all transactions
 	urgent, floating priceHeap  // Heap of prices of all the stored **remote** transactions
 	reheapMu         sync.Mutex // Mutex asserts that only one routine is reheaping the list
@@ -513,7 +513,7 @@ func (l *pricedList) Put(tx *types.Transaction, local bool) {
 // the heap if a large enough ratio of transactions go stale.
 func (l *pricedList) Removed(count int) {
 	// Bump the stale counter, but exit if still too low (< 25%)
-	stales := atomic.AddInt64(&l.stales, int64(count))
+	stales := l.stales.Add(int64(count))
 	if int(stales) <= (len(l.urgent.list)+len(l.floating.list))/4 {
 		return
 	}
@@ -538,7 +538,7 @@ func (l *pricedList) underpricedFor(h *priceHeap, tx *types.Transaction) bool {
 	for len(h.list) > 0 {
 		head := h.list[0]
 		if l.all.GetRemote(head.Hash()) == nil { // Removed or migrated
-			atomic.AddInt64(&l.stales, -1)
+			l.stales.Add(-1)
 			heap.Pop(h)
 			continue
 		}
@@ -565,7 +565,7 @@ func (l *pricedList) Cap(threshold *big.Int) types.Transactions {
 		cheapest := (l.urgent.list)[0]
 		if l.all.GetRemote(cheapest.Hash()) == nil { // Removed or migrated
 			heap.Pop(&l.urgent)
-			atomic.AddInt64(&l.stales, -1)
+			l.stales.Add(-1)
 			continue
 		}
 		// Stop the discards if we've reached the threshold
@@ -589,7 +589,7 @@ func (l *pricedList) Discard(slots int, force bool) (types.Transactions, bool) {
 			// Discard stale transactions if found during cleanup
 			tx := heap.Pop(&l.urgent).(*types.Transaction)
 			if l.all.GetRemote(tx.Hash()) == nil { // Removed or migrated
-				atomic.AddInt64(&l.stales, -1)
+				l.stales.Add(-1)
 				continue
 			}
 			// Non stale transaction found, move to floating heap
@@ -602,7 +602,7 @@ func (l *pricedList) Discard(slots int, force bool) (types.Transactions, bool) {
 			// Discard stale transactions if found during cleanup
 			tx := heap.Pop(&l.floating).(*types.Transaction)
 			if l.all.GetRemote(tx.Hash()) == nil { // Removed or migrated
-				atomic.AddInt64(&l.stales, -1)
+				l.stales.Add(-1)
 				continue
 			}
 			// Non stale transaction found, discard it
@@ -625,7 +625,7 @@ func (l *pricedList) Reheap() {
 	l.reheapMu.Lock()
 	defer l.reheapMu.Unlock()
 	start := time.Now()
-	atomic.StoreInt64(&l.stales, 0)
+	l.stales.Store(0)
 	l.urgent.list = make([]*types.Transaction, 0, l.all.RemoteCount())
 	l.all.Range(func(hash common.Hash, tx *types.Transaction, local bool) bool {
 		l.urgent.list = append(l.urgent.list, tx)

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -22,7 +22,6 @@ import (
 	"math/big"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/CortexFoundation/CortexTheseus/common"
@@ -380,7 +379,7 @@ func (pool *TxPool) loop() {
 			pool.mu.RLock()
 			pending, queued := pool.stats()
 			pool.mu.RUnlock()
-			stales := int(atomic.LoadInt64(&pool.priced.stales))
+			stales := int(pool.priced.stales.Load())
 
 			if pending != prevPending || queued != prevQueued || stales != prevStales {
 				log.Debug("Transaction pool status report", "executable", pending, "queued", queued, "stales", stales)

--- a/core/txpool/txpool2_test.go
+++ b/core/txpool/txpool2_test.go
@@ -79,7 +79,7 @@ func TestTransactionFutureAttack(t *testing.T) {
 
 	// Create the pool to test the limit enforcement with
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
+	blockchain := newTestBlockChain(1000000, statedb, new(event.Feed))
 	config := testTxPoolConfig
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
@@ -115,7 +115,7 @@ func TestTransactionFuture1559(t *testing.T) {
 	t.Parallel()
 	// Create the pool to test the pricing enforcement with
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
+	blockchain := newTestBlockChain(1000000, statedb, new(event.Feed))
 	pool := NewTxPool(testTxPoolConfig, eip1559Config, blockchain)
 	defer pool.Stop()
 
@@ -147,7 +147,7 @@ func TestTransactionZAttack(t *testing.T) {
 	t.Parallel()
 	// Create the pool to test the pricing enforcement with
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
+	blockchain := newTestBlockChain(1000000, statedb, new(event.Feed))
 	pool := NewTxPool(testTxPoolConfig, eip1559Config, blockchain)
 	defer pool.Stop()
 	// Create a number of test accounts, fund them and make transactions


### PR DESCRIPTION
Makes use of atomic.Uint64 instead of atomic by pointer