### PR TITLE
log: report error when ctx key is non-string

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -169,7 +169,7 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, term bool) {
 		k, ok := ctx[i].(string)
 		v := formatLogfmtValue(ctx[i+1], term)
 		if !ok {
-			k, v = errorKey, formatLogfmtValue(k, term)
+			k, v = errorKey, fmt.Sprintf("%+T is not a string key", ctx[i])
 		} else {
 			k = escapeString(k)
 		}
@@ -218,20 +218,20 @@ func JSONFormatOrderedEx(pretty, lineSeparated bool) Format {
 		}
 	}
 	return FormatFunc(func(r *Record) []byte {
-		props := make(map[string]interface{})
-
-		props[r.KeyNames.Time] = r.Time
-		props[r.KeyNames.Lvl] = r.Lvl.String()
-		props[r.KeyNames.Msg] = r.Msg
+		props := map[string]interface{}{
+			r.KeyNames.Time: r.Time,
+			r.KeyNames.Lvl:  r.Lvl.String(),
+			r.KeyNames.Msg:  r.Msg,
+		}
 
 		ctx := make([]string, len(r.Ctx))
 		for i := 0; i < len(r.Ctx); i += 2 {
-			k, ok := r.Ctx[i].(string)
-			if !ok {
-				props[errorKey] = fmt.Sprintf("%+v is not a string key,", r.Ctx[i])
+			if k, ok := r.Ctx[i].(string); ok {
+				ctx[i] = k
+				ctx[i+1] = formatLogfmtValue(r.Ctx[i+1], true)
+			} else {
+				props[errorKey] = fmt.Sprintf("%+T is not a string key,", r.Ctx[i])
 			}
-			ctx[i] = k
-			ctx[i+1] = formatLogfmtValue(r.Ctx[i+1], true)
 		}
 		props[r.KeyNames.Ctx] = ctx
 
@@ -261,18 +261,19 @@ func JSONFormatEx(pretty, lineSeparated bool) Format {
 	}
 
 	return FormatFunc(func(r *Record) []byte {
-		props := make(map[string]interface{})
-
-		props[r.KeyNames.Time] = r.Time
-		props[r.KeyNames.Lvl] = r.Lvl.String()
-		props[r.KeyNames.Msg] = r.Msg
+		props := map[string]interface{}{
+			r.KeyNames.Time: r.Time,
+			r.KeyNames.Lvl:  r.Lvl.String(),
+			r.KeyNames.Msg:  r.Msg,
+		}
 
 		for i := 0; i < len(r.Ctx); i += 2 {
 			k, ok := r.Ctx[i].(string)
 			if !ok {
-				props[errorKey] = fmt.Sprintf("%+v is not a string key", r.Ctx[i])
+				props[errorKey] = fmt.Sprintf("%+T is not a string key", r.Ctx[i])
+			} else {
+				props[k] = formatJSONValue(r.Ctx[i+1])
 			}
-			props[k] = formatJSONValue(r.Ctx[i+1])
 		}
 
 		b, err := jsonMarshal(props)


### PR DESCRIPTION
* log/format.go : invalid string cast fix

* log: some polish

---------