### PR TITLE
core/state: mark account as dirty when resetObject occurs

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -90,6 +90,7 @@ type (
 		account *common.Address
 	}
 	resetObjectChange struct {
+		account      *common.Address
 		prev         *stateObject
 		prevdestruct bool
 	}
@@ -167,7 +168,7 @@ func (ch resetObjectChange) revert(s *StateDB) {
 }
 
 func (ch resetObjectChange) dirtied() *common.Address {
-	return nil
+	return ch.account
 }
 
 func (ch suicideChange) revert(s *StateDB) {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -716,20 +716,16 @@ func (s *StateDB) GetOrNewStateObject(addr common.Address) *stateObject {
 // the given address, it is overwritten and returned as the second return value.
 func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) {
 	prev = s.getDeletedStateObject(addr) // Note, prev might have been deleted, we need that!
-
-	var prevdestruct bool
-	if prev != nil {
-		_, prevdestruct = s.stateObjectsDestruct[prev.address]
-		if !prevdestruct {
-			s.stateObjectsDestruct[prev.address] = struct{}{}
-		}
-	}
 	newobj = newObject(s, addr, types.StateAccount{})
 	//newobj.setNonce(0) // sets the object to dirty
 	if prev == nil {
 		s.journal.append(createObjectChange{account: &addr})
 	} else {
-		s.journal.append(resetObjectChange{prev: prev, prevdestruct: prevdestruct})
+		_, prevdestruct := s.stateObjectsDestruct[prev.address]
+		if !prevdestruct {
+			s.stateObjectsDestruct[prev.address] = struct{}{}
+		}
+		s.journal.append(resetObjectChange{account: &addr, prev: prev, prevdestruct: prevdestruct})
 	}
 	s.setStateObject(newobj)
 	if prev != nil && !prev.deleted {


### PR DESCRIPTION
This changes the journal logic to mark the state object dirty immediately when it is reset. 

We're mostly adding this change to appease the fuzzer. Marking it dirty immediately makes no difference in practice because accounts will always be modified by CVM right after creation.