### PR TITLE
core: remove unnecessary log copy 

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1978,11 +1978,10 @@ func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {
 	var logs []*types.Log
 	for _, receipt := range receipts {
 		for _, log := range receipt.Logs {
-			l := *log
 			if removed {
-				l.Removed = true
+				log.Removed = true
 			}
-			logs = append(logs, &l)
+			logs = append(logs, log)
 		}
 	}
 	return logs


### PR DESCRIPTION
The logs in this function are pulled straight from disk in rawdb.ReadRawReceipts and  also modified in receipts.DeriveFields, so removing the copy should be fine.