### PR TITLE
api/bind: add CallOpts.BlockHash to allow calling contracts at a spec…

### DIFF
--- a/accounts/abi/bind/backend.go
+++ b/accounts/abi/bind/backend.go
@@ -36,6 +36,10 @@ var (
 	// on a backend that doesn't implement PendingContractCaller.
 	ErrNoPendingState = errors.New("backend does not support pending state")
 
+	// ErrNoBlockHashState is raised when attempting to perform a block hash action
+	// on a backend that doesn't implement BlockHashContractCaller.
+	ErrNoBlockHashState = errors.New("backend does not support block hash state")
+
 	// ErrNoCodeAfterDeploy is returned by WaitDeployed if contract creation leaves
 	// an empty contract behind.
 	ErrNoCodeAfterDeploy = errors.New("no contract code after deployment")
@@ -62,6 +66,17 @@ type PendingContractCaller interface {
 
 	// PendingCallContract executes an Cortex contract call against the pending state.
 	PendingCallContract(ctx context.Context, call cortex.CallMsg) ([]byte, error)
+}
+
+// BlockHashContractCaller defines methods to perform contract calls on a specific block hash.
+// Call will try to discover this interface when access to a block by hash is requested.
+// If the backend does not support the block hash state, Call returns ErrNoBlockHashState.
+type BlockHashContractCaller interface {
+	// CodeAtHash returns the code of the given account in the state at the specified block hash.
+	CodeAtHash(ctx context.Context, contract common.Address, blockHash common.Hash) ([]byte, error)
+
+	// CallContractAtHash executes an Ethereum contract all against the state at the specified block hash.
+	CallContractAtHash(ctx context.Context, call cortex.CallMsg, blockHash common.Hash) ([]byte, error)
 }
 
 // ContractTransactor defines the methods needed to allow operating with a contract

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -48,6 +48,7 @@ type CallOpts struct {
 	Pending     bool            // Whether to operate on the pending state or the last known one
 	From        common.Address  // Optional the sender address, otherwise the first account is used
 	BlockNumber *big.Int        // Optional the block number on which the call should be performed
+	BlockHash   common.Hash     // Optional the block hash on which the call should be performed
 	Context     context.Context // Network context to support cancellation and timeouts (nil = no timeout)
 }
 
@@ -177,6 +178,23 @@ func (c *BoundContract) Call(opts *CallOpts, result interface{}, method string, 
 		if len(output) == 0 {
 			// Make sure we have a contract to operate on, and bail out otherwise.
 			if code, err = pb.PendingCodeAt(ctx, c.address); err != nil {
+				return err
+			} else if len(code) == 0 {
+				return ErrNoCode
+			}
+		}
+	} else if opts.BlockHash != (common.Hash{}) {
+		bh, ok := c.caller.(BlockHashContractCaller)
+		if !ok {
+			return ErrNoBlockHashState
+		}
+		output, err = bh.CallContractAtHash(ctx, msg, opts.BlockHash)
+		if err != nil {
+			return err
+		}
+		if len(output) == 0 {
+			// Make sure we have a contract to operate on, and bail out otherwise.
+			if code, err = bh.CodeAtHash(ctx, c.address, opts.BlockHash); err != nil {
 				return err
 			} else if len(code) == 0 {
 				return ErrNoCode

--- a/client/ctxc_client.go
+++ b/client/ctxc_client.go
@@ -383,6 +383,13 @@ func (ec *Client) BalanceAt(ctx context.Context, account common.Address, blockNu
 	return (*big.Int)(&result), err
 }
 
+// BalanceAtHash returns the wei balance of the given account.
+func (ec *Client) BalanceAtHash(ctx context.Context, account common.Address, blockHash common.Hash) (*big.Int, error) {
+	var result hexutil.Big
+	err := ec.c.CallContext(ctx, &result, "eth_getBalance", account, rpc.BlockNumberOrHashWithHash(blockHash, false))
+	return (*big.Int)(&result), err
+}
+
 // StorageAt returns the value of key in the contract storage of the given account.
 // The block number can be nil, in which case the value is taken from the latest known block.
 func (ec *Client) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {


### PR DESCRIPTION
…ific block hash

* api/bind: Add CallOpts.BlockHash to allow calling contracts at a specific block hash.

* client: Add BalanceAtHash, NonceAtHash and StorageAtHash functions