### PR TITLE
log: avoid setting default slog logger in init

### DIFF
--- a/log/root.go
+++ b/log/root.go
@@ -10,8 +10,7 @@ import (
 var root atomic.Value
 
 func init() {
-	defaultLogger := &logger{slog.New(DiscardHandler())}
-	SetDefault(defaultLogger)
+	root.Store(&logger{slog.New(DiscardHandler())})
 }
 
 // SetDefault sets the default global logger


### PR DESCRIPTION
slog.SetDefault has undesirable side effects. It also sets the default logger destination, for example. So we should not call it by default in init.