### PR TITLE
core/vm: refactor push-functions to use `min` builtin

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -1140,23 +1140,18 @@ func opPush1(pc *uint64, interpreter *CVMInterpreter, callContext *ScopeContext)
 
 // make push instruction function
 func makePush(size uint64, pushByteSize int) executionFunc {
-	return func(pc *uint64, interpreter *CVMInterpreter, callContext *ScopeContext) ([]byte, error) {
-		codeLen := len(callContext.Contract.Code)
-
-		startMin := codeLen
-		if int(*pc+1) < startMin {
-			startMin = int(*pc + 1)
-		}
-
-		endMin := codeLen
-		if startMin+pushByteSize < endMin {
-			endMin = startMin + pushByteSize
-		}
-
-		integer := new(uint256.Int)
-		callContext.Stack.push(integer.SetBytes(common.RightPadBytes(
-			callContext.Contract.Code[startMin:endMin], pushByteSize)))
-
+	return func(pc *uint64, interpreter *CVMInterpreter, scope *ScopeContext) ([]byte, error) {
+		var (
+			codeLen = len(scope.Contract.Code)
+			start   = min(codeLen, int(*pc+1))
+			end     = min(codeLen, start+pushByteSize)
+		)
+		scope.Stack.push(new(uint256.Int).SetBytes(
+			common.RightPadBytes(
+				scope.Contract.Code[start:end],
+				pushByteSize,
+			)),
+		)
 		*pc += size
 		return nil, nil
 	}

--- a/ctxc/downloader/downloader_test.go
+++ b/ctxc/downloader/downloader_test.go
@@ -541,8 +541,10 @@ func testCanonicalSynchronisation(t *testing.T, protocol int, mode SyncMode) {
 // func TestThrottling63Full(t *testing.T) { testThrottling(t, 63, FullSync) }
 // func TestThrottling63Fast(t *testing.T) { testThrottling(t, 63, FastSync) }
 func TestThrottling64Full(t *testing.T) { testThrottling(t, 64, FullSync) }
-//func TestThrottling64Fast(t *testing.T) { testThrottling(t, 64, FastSync) }
+
+// func TestThrottling64Fast(t *testing.T) { testThrottling(t, 64, FastSync) }
 func TestThrottling65Full(t *testing.T) { testThrottling(t, 65, FullSync) }
+
 //func TestThrottling65Fast(t *testing.T) { testThrottling(t, 65, FastSync) }
 
 func testThrottling(t *testing.T, protocol int, mode SyncMode) {


### PR DESCRIPTION
* optimize-push

* revert push1 change

* Update instructions.go

* core/vm: go format

* core/vm: fix nit

---------