### PR TITLE
common: using `ParseUint` instead of `ParseInt` 

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -456,7 +456,7 @@ func (d *Decimal) UnmarshalJSON(input []byte) error {
 	if !isString(input) {
 		return &json.UnmarshalTypeError{Value: "non-string", Type: reflect.TypeOf(uint64(0))}
 	}
-	if i, err := strconv.ParseInt(string(input[1:len(input)-1]), 10, 64); err == nil {
+	if i, err := strconv.ParseUint(string(input[1:len(input)-1]), 10, 64); err == nil {
 		*d = Decimal(i)
 		return nil
 	} else {

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -21,6 +21,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"strings"
@@ -597,4 +598,30 @@ func BenchmarkPrettyDuration(b *testing.B) {
 		a = x.String()
 	}
 	b.Logf("Post %s", a)
+}
+
+func TestDecimalUnmarshalJSON(t *testing.T) {
+	// These should error
+	for _, tc := range []string{``, `"`, `""`, `"-1"`} {
+		if err := new(Decimal).UnmarshalJSON([]byte(tc)); err == nil {
+			t.Errorf("input %s should cause error", tc)
+		}
+	}
+	// These should succeed
+	for _, tc := range []struct {
+		input string
+		want  uint64
+	}{
+		{`"0"`, 0},
+		{`"9223372036854775807"`, math.MaxInt64},
+		{`"18446744073709551615"`, math.MaxUint64},
+	} {
+		have := new(Decimal)
+		if err := have.UnmarshalJSON([]byte(tc.input)); err != nil {
+			t.Errorf("input %q triggered error: %v", tc.input, err)
+		}
+		if uint64(*have) != tc.want {
+			t.Errorf("input %q, have %d want %d", tc.input, *have, tc.want)
+		}
+	}
 }


### PR DESCRIPTION
Since Decimal is defined as unsiged `uint64`, we should use `strconv.ParseUint` instead of `strconv.ParseInt` during unmarshalling.

---------