### PR TITLE
p2p/nat: return correct port for ExtIP NAT

### DIFF
--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -138,8 +138,10 @@ func (n ExtIP) String() string              { return fmt.Sprintf("ExtIP(%v)", ne
 
 // These do nothing.
 
-func (ExtIP) AddMapping(string, int, int, string, time.Duration) (uint16, error) { return 0, nil }
-func (ExtIP) DeleteMapping(string, int, int) error                               { return nil }
+func (ExtIP) AddMapping(protocol string, extport, intport int, name string, lifetime time.Duration) (uint16, error) {
+	return uint16(extport), nil
+}
+func (ExtIP) DeleteMapping(string, int, int) error { return nil }
 
 // Any returns a port mapper that tries to discover any supported
 // mechanism on the local network.


### PR DESCRIPTION
Return the actually requested external port instead of 0 in the AddMapping implementation for `--nat extip:<IP>`.