### PR TITLE
internal/build: include git-date on detached head

### DIFF
--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -109,6 +109,7 @@ func LocalEnv() Environment {
 		commitRe, _ := regexp.Compile("^([0-9a-f]{40})$")
 		if commit := commitRe.FindString(head); commit != "" && env.Commit == "" {
 			env.Commit = commit
+			env.Date = getDate(env.Commit)
 		}
 		return env
 	}


### PR DESCRIPTION
When we are building in detached head, we cannot easily obtain the same information as we can if we're in non-detached head.

However, one thing we _can_ obtain is the git-hash and git-date. Currently, we omit to include the git-date into the build-info, which causes problem for reproducable builds which are on a detached head.

This change fixes it to include the date-info always.