### PR TITLE
build: bump test timeout

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -329,8 +329,8 @@ func doTest(cmdline []string) {
 	}
 	gotest := tc.Go("test")
 
-	// CI needs a bit more time for the statetests (default 10m).
-	gotest.Args = append(gotest.Args, "-timeout=30m")
+	// CI needs a bit more time for the statetests (default 45m).
+	gotest.Args = append(gotest.Args, "-timeout=45m")
 
 	// Enable CKZG backend in CI.
 	gotest.Args = append(gotest.Args, "-tags=ckzg")


### PR DESCRIPTION
Travis often fails because the test times out.