### PR TITLE
log: fix SetDefault for custom loggers

### DIFF
--- a/log/root_test.go
+++ b/log/root_test.go
@@ -1,0 +1,19 @@
+package log
+
+import (
+	"testing"
+)
+
+// SetDefault should properly set the default logger when custom loggers are
+// provided.
+func TestSetDefaultCustomLogger(t *testing.T) {
+	type customLogger struct {
+		Logger // Implement the Logger interface
+	}
+
+	customLog := &customLogger{}
+	SetDefault(customLog)
+	if Root() != customLog {
+		t.Error("expected custom logger to be set as default")
+	}
+}


### PR DESCRIPTION
Currently, even though it takes in a `Logger` interface, `log.SetDefualt` enforces that the concrete type of the provided logger is `*logger` because:
1. in `init` `root.Store` is called with a `*logger`
2. `atomic.Value` panics if the concrete type provided in `Store` is not consistent across calls.
([ref](https://pkg.go.dev/sync/atomic#Value.Store))

> All calls to Store for a given Value must use values of the same
concrete type.

This PR changes to use `sync.RWMutex` and adds a test that panics on `master`.