### PR TITLE
p2p: better dial/serve success metrics

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -51,6 +51,10 @@ var (
 	dialSuccessMeter    metrics.Meter = metrics.NilMeter{}
 	dialConnectionError metrics.Meter = metrics.NilMeter{}
 
+	// count peers that stayed connected for at least 1 min
+	serve1MinSuccessMeter = metrics.NewRegisteredMeter("p2p/serves/success/1min", nil)
+	dial1MinSuccessMeter  = metrics.NewRegisteredMeter("p2p/dials/success/1min", nil)
+
 	// handshake error meters
 	dialTooManyPeers        = metrics.NewRegisteredMeter("p2p/dials/error/saturated", nil)
 	dialAlreadyConnected    = metrics.NewRegisteredMeter("p2p/dials/error/known", nil)


### PR DESCRIPTION
Our previous success metrics gave success even if a peer disconnected right after connection. These metrics only count peers that stayed connected for at least 1 min. The 1 min limit is an arbitrary choice. We do not use this for decision logic, only statistics.