### PR TITLE
Update broken Riverbed SimulatedPacketLoss.pdf link in README

### DIFF
--- a/vendor/github.com/pion/transport/v3/vnet/README.md
+++ b/vendor/github.com/pion/transport/v3/vnet/README.md
@@ -227,5 +227,6 @@ func (a *Agent) listenUDP(...) error {
   - Total number of connection failure (TCP)
 
 ## References
-* [Comparing Simulated Packet Loss and RealWorld Network Congestion](https://www.riverbed.com/document/fpo/WhitePaper-Riverbed-SimulatedPacketLoss.pdf)
+* [Comparing Simulated Packet Loss and RealWorld Network Congestion](https://www.riverbed.com/document-repository/)  
+  (Note: The original Riverbed SimulatedPacketLoss.pdf is no longer available. Please search the Riverbed resource library for similar white papers.)
 * [wireguard-go using GVisor's netstack](https://github.com/WireGuard/wireguard-go/tree/master/tun/netstack)


### PR DESCRIPTION
The original link to the Riverbed white paper "WhitePaper-Riverbed-SimulatedPacketLoss.pdf" is no longer available (404).
Replaced it with a link to the official Riverbed Resource Library and added a note explaining that the original document is unavailable and suggesting users search the library for similar white papers.
This ensures that the reference remains useful and avoids pointing to a dead link.