### PR TITLE
fix: inconsistance in error message

### DIFF
--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -45,7 +45,7 @@ func TestReadNodesCycle(t *testing.T) {
 	nodes := ReadNodes(iter, 10)
 	checkNodes(t, nodes, 3)
 	if iter.count != 10 {
-		t.Fatalf("%d calls to Next, want %d", iter.count, 100)
+		t.Fatalf("%d calls to Next, want %d", iter.count, 10)
 	}
 }
 


### PR DESCRIPTION
The error message says 100, but the test expects 10 calls. This is a mismatch between the expected value in the code and the error message.