### PR TITLE
chore: fix some function names in comment

### DIFF
--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -57,7 +57,7 @@ type StateTrie struct {
 	secKeyCache map[common.Hash][]byte
 }
 
-// NewSecure creates a trie with an existing root node from a backing database
+// NewStateTrie creates a trie with an existing root node from a backing database
 // and optional intermediate in-memory node pool.
 //
 // If root is the zero hash or the sha3 hash of an empty string, the

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -853,7 +853,7 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 	}
 }
 
-// BenchmarkCommitAfterHashFixedSize benchmarks the Commit (after Hash) of a fixed number of updates to a trie.
+// BenchmarkHashFixedSize benchmarks the Hash of a fixed number of updates to a trie.
 // This benchmark is meant to capture the difference on efficiency of small versus large changes. Typically,
 // storage tries are small (a couple of entries), whereas the full post-block account trie update is large (a couple
 // of thousand entries)


### PR DESCRIPTION
fix some function names in comment