### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2076,9 +2076,9 @@ func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator) (i
 		blocks []*types.Block
 		memory uint64
 	)
-	for i := len(hashes) - 1; i >= 0; i-- {
+	for i, hashe := range slices.Backward(hashes) {
 		// Append the next block to our batch
-		block := bc.GetBlock(hashes[i], numbers[i])
+		block := bc.GetBlock(hashe, numbers[i])
 
 		blocks = append(blocks, block)
 		memory += block.Size()
@@ -2226,8 +2226,8 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Header) error {
 
 	// Deleted logs + blocks:
 	{
-		for i := len(oldChain) - 1; i >= 0; i-- {
-			block := bc.GetBlock(oldChain[i].Hash(), oldChain[i].Number.Uint64())
+		for _, o := range slices.Backward(oldChain) {
+			block := bc.GetBlock(o.Hash(), o.Number.Uint64())
 			if block == nil {
 				return errInvalidOldChain // Corrupt database, mostly here to avoid weird panics
 			}

--- a/crypto/bls12381/g1.go
+++ b/crypto/bls12381/g1.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"slices"
 )
 
 // PointG1 is type for point in G1.
@@ -397,8 +398,8 @@ func (g *G1) MultiExp(r *PointG1, points []*PointG1, powers []*big.Int) (*PointG
 			powers[i] = new(big.Int).Rsh(powers[i], uint(c))
 		}
 		sum.Zero()
-		for i := len(bucket) - 1; i >= 0; i-- {
-			g.Add(sum, sum, bucket[i])
+		for _, b := range slices.Backward(bucket) {
+			g.Add(sum, sum, b)
 			g.Add(acc, acc, sum)
 		}
 		windows[j] = g.New()
@@ -407,11 +408,11 @@ func (g *G1) MultiExp(r *PointG1, points []*PointG1, powers []*big.Int) (*PointG
 		cur += c
 	}
 	acc.Zero()
-	for i := len(windows) - 1; i >= 0; i-- {
+	for _, window := range slices.Backward(windows) {
 		for j := uint32(0); j < c; j++ {
 			g.Double(acc, acc)
 		}
-		g.Add(acc, acc, windows[i])
+		g.Add(acc, acc, window)
 	}
 	return r.Set(acc), nil
 }

--- a/crypto/bls12381/g2.go
+++ b/crypto/bls12381/g2.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"slices"
 )
 
 // PointG2 is type for point in G2.
@@ -418,8 +419,8 @@ func (g *G2) MultiExp(r *PointG2, points []*PointG2, powers []*big.Int) (*PointG
 			powers[i] = new(big.Int).Rsh(powers[i], uint(c))
 		}
 		sum.Zero()
-		for i := len(bucket) - 1; i >= 0; i-- {
-			g.Add(sum, sum, bucket[i])
+		for _, b := range slices.Backward(bucket) {
+			g.Add(sum, sum, b)
 			g.Add(acc, acc, sum)
 		}
 		windows[j] = g.New()
@@ -428,11 +429,11 @@ func (g *G2) MultiExp(r *PointG2, points []*PointG2, powers []*big.Int) (*PointG
 		cur += c
 	}
 	acc.Zero()
-	for i := len(windows) - 1; i >= 0; i-- {
+	for _, window := range slices.Backward(windows) {
 		for j := uint32(0); j < c; j++ {
 			g.Double(acc, acc)
 		}
-		g.Add(acc, acc, windows[i])
+		g.Add(acc, acc, window)
 	}
 	return r.Set(acc), nil
 }

--- a/ctxc/downloader/downloader.go
+++ b/ctxc/downloader/downloader.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -790,14 +791,14 @@ func (d *Downloader) findAncestorSpanSearch(p *peerConnection, mode SyncMode, re
 			}
 			// Check if a common ancestor was found
 			finished = true
-			for i := len(headers) - 1; i >= 0; i-- {
+			for _, header := range slices.Backward(headers) {
 				// Skip any headers that underflow/overflow our requested set
-				if headers[i].Number.Int64() < from || headers[i].Number.Uint64() > max {
+				if header.Number.Int64() < from || header.Number.Uint64() > max {
 					continue
 				}
 				// Otherwise check if we already know the header or not
-				h := headers[i].Hash()
-				n := headers[i].Number.Uint64()
+				h := header.Hash()
+				n := header.Number.Uint64()
 
 				var known bool
 				switch mode {

--- a/ctxc/tracers/logger/logger.go
+++ b/ctxc/tracers/logger/logger.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"slices"
 	"strings"
 	"sync/atomic"
 
@@ -291,8 +292,8 @@ func WriteTrace(writer io.Writer, logs []StructLog) {
 
 		if len(log.Stack) > 0 {
 			fmt.Fprintln(writer, "Stack:")
-			for i := len(log.Stack) - 1; i >= 0; i-- {
-				fmt.Fprintf(writer, "%08d  %s\n", len(log.Stack)-i-1, log.Stack[i].Hex())
+			for i, v := range slices.Backward(log.Stack) {
+				fmt.Fprintf(writer, "%08d  %s\n", len(log.Stack)-i-1, v.Hex())
 			}
 		}
 		if len(log.Memory) > 0 {

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"math/big"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -115,8 +116,8 @@ func (err *decodeError) Error() string {
 	ctx := ""
 	if len(err.ctx) > 0 {
 		ctx = ", decoding into "
-		for i := len(err.ctx) - 1; i >= 0; i-- {
-			ctx += err.ctx[i]
+		for _, v := range slices.Backward(err.ctx) {
+			ctx += v
 		}
 	}
 	return fmt.Sprintf("rlp: %s for %v%s", err.msg, err.typ, ctx)


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899